### PR TITLE
digestset: add util functions to digest files and byte arrays

### DIFF
--- a/pkg/attestation/artifact/artifact.go
+++ b/pkg/attestation/artifact/artifact.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"encoding/json"
 	"io/fs"
-	"os"
 	"path/filepath"
 
 	"github.com/testifysec/witness/pkg/attestation"
@@ -90,7 +89,7 @@ func recordArtifacts(basePath string, baseArtifacts map[string]witcrypt.DigestSe
 			return err
 		}
 
-		artifact, err := recordArtifact(path, hashes)
+		artifact, err := witcrypt.CalculateDigestSetFromFile(path, hashes)
 		if err != nil {
 			return err
 		}
@@ -107,24 +106,4 @@ func recordArtifacts(basePath string, baseArtifacts map[string]witcrypt.DigestSe
 	})
 
 	return artifacts, err
-}
-
-func recordArtifact(path string, hashes []crypto.Hash) (witcrypt.DigestSet, error) {
-	artifact := make(witcrypt.DigestSet)
-	f, err := os.Open(path)
-	if err != nil {
-		return artifact, err
-	}
-
-	defer f.Close()
-	for _, h := range hashes {
-		digest, err := witcrypt.Digest(f, h)
-		if err != nil {
-			return artifact, err
-		}
-
-		artifact[h] = string(witcrypt.HexEncode(digest))
-	}
-
-	return artifact, nil
 }

--- a/pkg/attestation/gcp-iit/gcp-iit.go
+++ b/pkg/attestation/gcp-iit/gcp-iit.go
@@ -108,32 +108,32 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		a.getInstanceData()
 	}
 
-	instanceIDSubject, err := crypto.CalculateDigestSet([]byte(a.InstanceID), ctx.Hashes())
+	instanceIDSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.InstanceID), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 	a.subjects[a.InstanceID] = instanceIDSubject
 
-	instanceHostnameSubject, err := crypto.CalculateDigestSet([]byte(a.InstanceHostname), ctx.Hashes())
+	instanceHostnameSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.InstanceHostname), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 	a.subjects[a.InstanceHostname] = instanceHostnameSubject
 
-	projectIDSubject, err := crypto.CalculateDigestSet([]byte(a.ProjectID), ctx.Hashes())
+	projectIDSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.ProjectID), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 	a.subjects[a.ProjectID] = projectIDSubject
 
-	projectNumberSubject, err := crypto.CalculateDigestSet([]byte(a.ProjectNumber), ctx.Hashes())
+	projectNumberSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.ProjectNumber), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 
 	a.subjects[a.ProjectNumber] = projectNumberSubject
 
-	clusterUIDSubejct, err := crypto.CalculateDigestSet([]byte(a.ClusterUID), ctx.Hashes())
+	clusterUIDSubejct, err := crypto.CalculateDigestSetFromBytes([]byte(a.ClusterUID), ctx.Hashes())
 	if err != nil {
 		return err
 	}

--- a/pkg/attestation/gitlab/gitlab.go
+++ b/pkg/attestation/gitlab/gitlab.go
@@ -84,13 +84,13 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	a.RunnerID = os.Getenv("CI_RUNNER_ID")
 	a.CIHost = os.Getenv("CI_SERVER_HOST")
 
-	pipelineSubj, err := crypto.CalculateDigestSet([]byte(a.PipelineUrl), ctx.Hashes())
+	pipelineSubj, err := crypto.CalculateDigestSetFromBytes([]byte(a.PipelineUrl), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 
 	a.subjects[a.PipelineUrl] = pipelineSubj
-	jobSubj, err := crypto.CalculateDigestSet([]byte(a.JobUrl), ctx.Hashes())
+	jobSubj, err := crypto.CalculateDigestSetFromBytes([]byte(a.JobUrl), ctx.Hashes())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a few functions to make calculating digests of files and byte
arrays easier and more seamless.  CalculateDigestSetFromFile takes in a
file path and CalculateDigestSetFromBytes takes in a byte array.
CalculateDigestSet now operates on readers for a more generalalized API.