### PR TITLE
Fix link to email

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ cat attestation.json | jq -r .payload | base64 -d | jq
 ## Support
 
 [TestifySec](https://testifysec.com) Provides support for witness and other CI security tools.
-[Contact Us](info@testifysec.com)
+[Contact Us](mailto:info@testifysec.com)


### PR DESCRIPTION
The email link in the README resolved to a relative website url on github which pointed at a 404 page. This moves it to a markdown mailto link which will engage the mail client.