### PR TITLE
pkg/crypto renamed to pkg/cryptoutil

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/spiffe"
 
 	// imported so their init functions run
@@ -49,7 +49,7 @@ func addKeyFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&spiffePath, "spiffe-socket", "", "Path to the SPIFFE Workload API socket")
 }
 
-func loadSigner() (crypto.Signer, error) {
+func loadSigner() (cryptoutil.Signer, error) {
 	if spiffePath == "" && keyPath == "" {
 		return nil, fmt.Errorf("one of key or spiffe-socket flags must be provided")
 	} else if spiffePath != "" && keyPath != "" {
@@ -66,13 +66,13 @@ func loadSigner() (crypto.Signer, error) {
 	}
 
 	defer keyFile.Close()
-	key, err := crypto.TryParseKeyFromReader(keyFile)
+	key, err := cryptoutil.TryParseKeyFromReader(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load key: %v", err)
 	}
 
 	if certPath == "" {
-		return crypto.NewSigner(key)
+		return cryptoutil.NewSigner(key)
 	}
 
 	leaf, err := loadCert(certPath)
@@ -90,7 +90,7 @@ func loadSigner() (crypto.Signer, error) {
 		intermediates = append(intermediates, cert)
 	}
 
-	return crypto.NewX509Signer(key, leaf, intermediates, nil)
+	return cryptoutil.NewX509Signer(key, leaf, intermediates, nil)
 }
 
 func loadCert(path string) (*x509.Certificate, error) {
@@ -100,7 +100,7 @@ func loadCert(path string) (*x509.Certificate, error) {
 	}
 
 	defer certFile.Close()
-	possibleCert, err := crypto.TryParseKeyFromReader(certFile)
+	possibleCert, err := cryptoutil.TryParseKeyFromReader(certFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse certificate")
 	}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	witness "github.com/testifysec/witness/pkg"
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/policy"
 )
 
@@ -45,7 +45,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	}
 
 	defer keyFile.Close()
-	verifier, err := crypto.NewVerifierFromReader(keyFile)
+	verifier, err := cryptoutil.NewVerifierFromReader(keyFile)
 	if err != nil {
 		return fmt.Errorf("failed to load key: %v", err)
 	}

--- a/pkg/attestation/artifact/artifact.go
+++ b/pkg/attestation/artifact/artifact.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/testifysec/witness/pkg/attestation"
-	witcrypt "github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 const (
@@ -23,15 +23,15 @@ func init() {
 
 type Option func(*Attestor)
 
-func WithBaseArtifacts(baseArtifacts map[string]witcrypt.DigestSet) Option {
+func WithBaseArtifacts(baseArtifacts map[string]cryptoutil.DigestSet) Option {
 	return func(attestor *Attestor) {
 		attestor.baseArtifacts = baseArtifacts
 	}
 }
 
 type Attestor struct {
-	Artifacts     map[string]witcrypt.DigestSet `json:"artifacts"`
-	baseArtifacts map[string]witcrypt.DigestSet
+	Artifacts     map[string]cryptoutil.DigestSet `json:"artifacts"`
+	baseArtifacts map[string]cryptoutil.DigestSet
 }
 
 func (a Attestor) Name() string {
@@ -66,15 +66,15 @@ func (a *Attestor) MarshalJSON() ([]byte, error) {
 }
 
 func (a *Attestor) UnmarshalJSON(data []byte) error {
-	attestations := make(map[string]witcrypt.DigestSet)
+	attestations := make(map[string]cryptoutil.DigestSet)
 	return json.Unmarshal(data, &attestations)
 }
 
 // recordArtifacts will walk basePath and record the digests of each file with each of the functions in hashes.
 // If file already exists in baseArtifacts and the two artifacts are equal the artifact will not be in the
 // returned map of artifacts.
-func recordArtifacts(basePath string, baseArtifacts map[string]witcrypt.DigestSet, hashes []crypto.Hash) (map[string]witcrypt.DigestSet, error) {
-	artifacts := make(map[string]witcrypt.DigestSet)
+func recordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []crypto.Hash) (map[string]cryptoutil.DigestSet, error) {
+	artifacts := make(map[string]cryptoutil.DigestSet)
 	err := filepath.Walk(basePath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func recordArtifacts(basePath string, baseArtifacts map[string]witcrypt.DigestSe
 			return err
 		}
 
-		artifact, err := witcrypt.CalculateDigestSetFromFile(path, hashes)
+		artifact, err := cryptoutil.CalculateDigestSetFromFile(path, hashes)
 		if err != nil {
 			return err
 		}

--- a/pkg/attestation/collection.go
+++ b/pkg/attestation/collection.go
@@ -3,7 +3,7 @@ package attestation
 import (
 	"encoding/json"
 
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 const CollectionType = "https://witness.testifysec.com/AttestationCollection/v0.1"
@@ -63,8 +63,8 @@ func (c *CollectionAttestation) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *Collection) Subjects() map[string]crypto.DigestSet {
-	allSubjects := make(map[string]crypto.DigestSet)
+func (c *Collection) Subjects() map[string]cryptoutil.DigestSet {
+	allSubjects := make(map[string]cryptoutil.DigestSet)
 	for _, collectionAttestation := range c.Attestations {
 		if subjecter, ok := collectionAttestation.Attestation.(Subjecter); ok {
 			subjects := subjecter.Subjects()

--- a/pkg/attestation/commandrun/commandrun.go
+++ b/pkg/attestation/commandrun/commandrun.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/testifysec/witness/pkg/attestation"
 	"github.com/testifysec/witness/pkg/attestation/artifact"
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 const (
@@ -28,7 +28,7 @@ func WithCommand(cmd []string) Option {
 	}
 }
 
-func WithMaterials(materials map[string]crypto.DigestSet) Option {
+func WithMaterials(materials map[string]cryptoutil.DigestSet) Option {
 	return func(cr *CommandRun) {
 		cr.materials = materials
 	}
@@ -63,7 +63,7 @@ type CommandRun struct {
 	Products  *artifact.Attestor `json:"products"`
 	Processes []ProcessInfo      `json:"processes,omitempty"`
 
-	materials     map[string]crypto.DigestSet
+	materials     map[string]cryptoutil.DigestSet
 	enableTracing bool
 }
 
@@ -99,7 +99,7 @@ func (rc *CommandRun) Type() string {
 	return Type
 }
 
-func (rc *CommandRun) Subjects() map[string]crypto.DigestSet {
+func (rc *CommandRun) Subjects() map[string]cryptoutil.DigestSet {
 	return rc.Products.Artifacts
 }
 

--- a/pkg/attestation/factory.go
+++ b/pkg/attestation/factory.go
@@ -3,7 +3,7 @@ package attestation
 import (
 	"fmt"
 
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 var (
@@ -18,7 +18,7 @@ type Attestor interface {
 }
 
 type Subjecter interface {
-	Subjects() map[string]crypto.DigestSet
+	Subjects() map[string]cryptoutil.DigestSet
 }
 
 type AttestorFactory func() Attestor

--- a/pkg/attestation/gcp-iit/gcp-iit.go
+++ b/pkg/attestation/gcp-iit/gcp-iit.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -57,12 +57,12 @@ type Attestor struct {
 	ClusterUID                string        `json:"cluster_uid"`
 	ClusterLocation           string        `json:"cluster_location"`
 
-	subjects map[string]crypto.DigestSet
+	subjects map[string]cryptoutil.DigestSet
 }
 
 func New() *Attestor {
 	return &Attestor{
-		subjects: make(map[string]crypto.DigestSet),
+		subjects: make(map[string]cryptoutil.DigestSet),
 	}
 }
 
@@ -108,32 +108,32 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		a.getInstanceData()
 	}
 
-	instanceIDSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.InstanceID), ctx.Hashes())
+	instanceIDSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.InstanceID), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 	a.subjects[a.InstanceID] = instanceIDSubject
 
-	instanceHostnameSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.InstanceHostname), ctx.Hashes())
+	instanceHostnameSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.InstanceHostname), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 	a.subjects[a.InstanceHostname] = instanceHostnameSubject
 
-	projectIDSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.ProjectID), ctx.Hashes())
+	projectIDSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ProjectID), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 	a.subjects[a.ProjectID] = projectIDSubject
 
-	projectNumberSubject, err := crypto.CalculateDigestSetFromBytes([]byte(a.ProjectNumber), ctx.Hashes())
+	projectNumberSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ProjectNumber), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 
 	a.subjects[a.ProjectNumber] = projectNumberSubject
 
-	clusterUIDSubejct, err := crypto.CalculateDigestSetFromBytes([]byte(a.ClusterUID), ctx.Hashes())
+	clusterUIDSubejct, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ClusterUID), ctx.Hashes())
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (a *Attestor) getInstanceData() {
 
 }
 
-func (a *Attestor) Subjects() map[string]crypto.DigestSet {
+func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	return a.subjects
 }
 

--- a/pkg/attestation/git/git.go
+++ b/pkg/attestation/git/git.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/testifysec/witness/pkg/attestation"
-	witcrypt "github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 const (
@@ -81,9 +81,9 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	return nil
 }
 
-func (a *Attestor) Subjects() map[string]witcrypt.DigestSet {
+func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	subjectName := fmt.Sprintf("git:%v", a.CommitHash)
-	return map[string]witcrypt.DigestSet{
+	return map[string]cryptoutil.DigestSet{
 		subjectName: {
 			crypto.SHA1: a.CommitHash,
 		},

--- a/pkg/attestation/gitlab/gitlab.go
+++ b/pkg/attestation/gitlab/gitlab.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/testifysec/witness/pkg/attestation"
 	"github.com/testifysec/witness/pkg/attestation/jwt"
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 const (
@@ -41,12 +41,12 @@ type Attestor struct {
 	RunnerID     string        `json:"runnerid"`
 	CIHost       string        `json:"cihost"`
 
-	subjects map[string]crypto.DigestSet
+	subjects map[string]cryptoutil.DigestSet
 }
 
 func New() *Attestor {
 	return &Attestor{
-		subjects: make(map[string]crypto.DigestSet),
+		subjects: make(map[string]cryptoutil.DigestSet),
 	}
 }
 
@@ -84,13 +84,13 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	a.RunnerID = os.Getenv("CI_RUNNER_ID")
 	a.CIHost = os.Getenv("CI_SERVER_HOST")
 
-	pipelineSubj, err := crypto.CalculateDigestSetFromBytes([]byte(a.PipelineUrl), ctx.Hashes())
+	pipelineSubj, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.PipelineUrl), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 
 	a.subjects[a.PipelineUrl] = pipelineSubj
-	jobSubj, err := crypto.CalculateDigestSetFromBytes([]byte(a.JobUrl), ctx.Hashes())
+	jobSubj, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.JobUrl), ctx.Hashes())
 	if err != nil {
 		return err
 	}
@@ -99,6 +99,6 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	return nil
 }
 
-func (a *Attestor) Subjects() map[string]crypto.DigestSet {
+func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	return a.subjects
 }

--- a/pkg/cryptoutil/digestset.go
+++ b/pkg/cryptoutil/digestset.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"bytes"

--- a/pkg/cryptoutil/ecdsa.go
+++ b/pkg/cryptoutil/ecdsa.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"crypto"

--- a/pkg/cryptoutil/ed25519.go
+++ b/pkg/cryptoutil/ed25519.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"crypto"

--- a/pkg/cryptoutil/rsa.go
+++ b/pkg/cryptoutil/rsa.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"crypto"

--- a/pkg/cryptoutil/signer.go
+++ b/pkg/cryptoutil/signer.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"crypto"

--- a/pkg/cryptoutil/util.go
+++ b/pkg/cryptoutil/util.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"bytes"

--- a/pkg/cryptoutil/verifier.go
+++ b/pkg/cryptoutil/verifier.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"crypto"

--- a/pkg/cryptoutil/x509.go
+++ b/pkg/cryptoutil/x509.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"crypto/x509"

--- a/pkg/cryptoutil/x509_test.go
+++ b/pkg/cryptoutil/x509_test.go
@@ -1,4 +1,4 @@
-package crypto
+package cryptoutil
 
 import (
 	"bytes"

--- a/pkg/dsse/dsse.go
+++ b/pkg/dsse/dsse.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 type ErrNoSignatures struct{}
@@ -46,7 +46,7 @@ func preauthEncode(bodyType string, body []byte) []byte {
 }
 
 // TODO: it'd be nice to break some of this logic out of what should be a presentation layer only
-func Sign(bodyType string, body io.Reader, signers ...crypto.Signer) (Envelope, error) {
+func Sign(bodyType string, body io.Reader, signers ...cryptoutil.Signer) (Envelope, error) {
 	env := Envelope{}
 	// TODO: refactor this so we don't read the entire reader into memory.
 	// the PAE has the length of the body as part of it, so path of least
@@ -76,7 +76,7 @@ func Sign(bodyType string, body io.Reader, signers ...crypto.Signer) (Envelope, 
 			Signature: sig,
 		}
 
-		if trustBundler, ok := signer.(crypto.TrustBundler); ok {
+		if trustBundler, ok := signer.(cryptoutil.TrustBundler); ok {
 			leaf := trustBundler.Certificate()
 			intermediates := trustBundler.Intermediates()
 			if leaf != nil {
@@ -94,7 +94,7 @@ func Sign(bodyType string, body io.Reader, signers ...crypto.Signer) (Envelope, 
 	return env, nil
 }
 
-func (e Envelope) Verify(verifiers ...crypto.Verifier) error {
+func (e Envelope) Verify(verifiers ...cryptoutil.Verifier) error {
 	pae := preauthEncode(e.PayloadType, e.Payload)
 	if len(e.Signatures) == 0 {
 		return ErrNoSignatures{}

--- a/pkg/intoto/statement.go
+++ b/pkg/intoto/statement.go
@@ -3,7 +3,7 @@ package intoto
 import (
 	"encoding/json"
 
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 const StatementType = "https://in-toto.io/Statement/v0.1"
@@ -21,7 +21,7 @@ type Statement struct {
 	Predicate     json.RawMessage `json:"predicate"`
 }
 
-func NewStatement(predicateType string, predicate []byte, subjects map[string]crypto.DigestSet) (Statement, error) {
+func NewStatement(predicateType string, predicate []byte, subjects map[string]cryptoutil.DigestSet) (Statement, error) {
 	statement := Statement{
 		Type:          StatementType,
 		PredicateType: predicateType,
@@ -41,7 +41,7 @@ func NewStatement(predicateType string, predicate []byte, subjects map[string]cr
 	return statement, nil
 }
 
-func DigestSetToSubject(name string, ds crypto.DigestSet) (Subject, error) {
+func DigestSetToSubject(name string, ds cryptoutil.DigestSet) (Subject, error) {
 	subj := Subject{
 		Name: name,
 	}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/testifysec/witness/pkg/attestation"
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/dsse"
 	"github.com/testifysec/witness/pkg/intoto"
 )
@@ -84,10 +84,10 @@ type PublicKey struct {
 	Key   []byte `json:"key"`
 }
 
-func (p Policy) loadPublicKeys() (map[string]crypto.Verifier, error) {
-	verifiers := make(map[string]crypto.Verifier, 0)
+func (p Policy) loadPublicKeys() (map[string]cryptoutil.Verifier, error) {
+	verifiers := make(map[string]cryptoutil.Verifier, 0)
 	for _, key := range p.PublicKeys {
-		verifier, err := crypto.NewVerifierFromReader(bytes.NewReader(key.Key))
+		verifier, err := cryptoutil.NewVerifierFromReader(bytes.NewReader(key.Key))
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func (p Policy) loadRoots() (map[string]trustBundle, error) {
 }
 
 func parseCertificate(data []byte) (*x509.Certificate, error) {
-	possibleCert, err := crypto.TryParseKeyFromReader(bytes.NewReader(data))
+	possibleCert, err := cryptoutil.TryParseKeyFromReader(bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (p Policy) verifyCollections(signedCollections []io.Reader) (map[string][]a
 			continue
 		}
 
-		functionaries := make([]crypto.Verifier, 0)
+		functionaries := make([]cryptoutil.Verifier, 0)
 		for _, functionary := range step.Functionaries {
 			if functionary.PublicKeyID != "" {
 				pubKey, ok := publicKeysByID[functionary.PublicKeyID]
@@ -276,7 +276,7 @@ func (p Policy) verifyCollections(signedCollections []io.Reader) (map[string][]a
 						intermediates = append(intermediates, intermediate)
 					}
 
-					verifier, err := crypto.NewX509Verifier(cert, intermediates, []*x509.Certificate{bundle.root})
+					verifier, err := cryptoutil.NewX509Verifier(cert, intermediates, []*x509.Certificate{bundle.root})
 					functionaries = append(functionaries, verifier)
 				}
 			}

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -16,19 +16,19 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testifysec/witness/pkg/attestation"
 	"github.com/testifysec/witness/pkg/attestation/commandrun"
-	witcrypt "github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/dsse"
 	"github.com/testifysec/witness/pkg/intoto"
 )
 
-func createTestKey() (witcrypt.Signer, witcrypt.Verifier, []byte, error) {
+func createTestKey() (cryptoutil.Signer, cryptoutil.Verifier, []byte, error) {
 	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	signer := witcrypt.NewRSASigner(privKey, crypto.SHA256)
-	verifier := witcrypt.NewRSAVerifier(&privKey.PublicKey, crypto.SHA256)
+	signer := cryptoutil.NewRSASigner(privKey, crypto.SHA256)
+	verifier := cryptoutil.NewRSAVerifier(&privKey.PublicKey, crypto.SHA256)
 	keyBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
 	if err != nil {
 		return nil, nil, nil, err
@@ -75,7 +75,7 @@ func TestVerify(t *testing.T) {
 
 	step1Collection := attestation.NewCollection("step1", []attestation.Attestor{commandrun.New()})
 	step1CollectionJson, err := json.Marshal(&step1Collection)
-	intotoStatement, err := intoto.NewStatement(attestation.CollectionType, step1CollectionJson, map[string]witcrypt.DigestSet{})
+	intotoStatement, err := intoto.NewStatement(attestation.CollectionType, step1CollectionJson, map[string]cryptoutil.DigestSet{})
 	require.NoError(t, err)
 	statementJson, err := json.Marshal(&intotoStatement)
 	require.NoError(t, err)

--- a/pkg/sign.go
+++ b/pkg/sign.go
@@ -3,11 +3,11 @@ package pkg
 import (
 	"io"
 
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/dsse"
 )
 
-func Sign(r io.Reader, dataType string, w io.Writer, signers ...crypto.Signer) error {
+func Sign(r io.Reader, dataType string, w io.Writer, signers ...cryptoutil.Signer) error {
 	env, err := dsse.Sign(dataType, r, signers...)
 	if err != nil {
 		return err

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
-	witcrypt "github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 type ErrInvalidSVID string
@@ -14,7 +14,7 @@ func (e ErrInvalidSVID) Error() string {
 	return fmt.Sprintf("invalid svid: %v", string(e))
 }
 
-func Signer(ctx context.Context, socketPath string) (*witcrypt.X509Signer, error) {
+func Signer(ctx context.Context, socketPath string) (*cryptoutil.X509Signer, error) {
 	svidCtx, err := workloadapi.FetchX509Context(ctx, workloadapi.WithAddr(socketPath))
 	if err != nil {
 		return nil, err
@@ -29,5 +29,5 @@ func Signer(ctx context.Context, socketPath string) (*witcrypt.X509Signer, error
 		return nil, ErrInvalidSVID("no private key")
 	}
 
-	return witcrypt.NewX509Signer(svid.PrivateKey, svid.Certificates[0], svid.Certificates[1:], nil)
+	return cryptoutil.NewX509Signer(svid.PrivateKey, svid.Certificates[0], svid.Certificates[1:], nil)
 }

--- a/pkg/verify.go
+++ b/pkg/verify.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/testifysec/witness/pkg/crypto"
+	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/dsse"
 )
 
-func VerifySignature(r io.Reader, verifiers ...crypto.Verifier) (dsse.Envelope, error) {
+func VerifySignature(r io.Reader, verifiers ...cryptoutil.Verifier) (dsse.Envelope, error) {
 	envelope, err := dsse.Decode(r)
 	if err != nil {
 		return envelope, fmt.Errorf("could not parse dsse envelope: %v", err)


### PR DESCRIPTION
May as well rip the band-aid off now and rename this. Probably wasn't
the best choice to name a witness package the same as a stdlib package.
Cryptoutil seems an apt name for what the package contains.

Fixes #9 