### PR TITLE
Feature/viper config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 vendor/
+.dccache

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func initConfig() {
+	v := viper.New()
+
+	if _, err := os.Stat(config); errors.Is(err, os.ErrNotExist) {
+		if rootCmd.Flags().Lookup("config").Changed {
+			log.Fatalf("config file %s does not exist", config)
+		} else {
+			log.Printf("%s does not exist, using command line arguments", config)
+			return
+		}
+	}
+
+	v.SetConfigFile(config)
+
+	if v.ConfigFileUsed() != "" {
+		log.Println("Using config file:", v.ConfigFileUsed())
+	}
+
+	if err := v.ReadInConfig(); err != nil {
+		log.Fatalf("Error reading config file: %s", err)
+	}
+
+	//Currently we do not accept configuration for root commands
+	commands := rootCmd.Commands()
+
+	for _, cmd := range commands {
+		flags := cmd.Flags()
+		flags.VisitAll(func(f *pflag.Flag) {
+			configKey := fmt.Sprintf("%s.%s", cmd.Name(), f.Name)
+			configValue := v.GetString(configKey)
+			if configValue != "" && !f.Changed {
+				f.Value.Set(v.GetString(configKey))
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,10 +25,15 @@ var keyPath string
 var certPath string
 var intermediatePaths []string
 var spiffePath string
+var config string
 
 var rootCmd = &cobra.Command{
 	Use:   "witness",
 	Short: "Collect and verify attestations about your build environments",
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&config, "config", "c", ".witness.yaml", "Path to the witness config file")
 }
 
 func Execute() {
@@ -44,7 +49,7 @@ func GetCommand() *cobra.Command {
 
 func addKeyFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&keyPath, "key", "k", "", "Path to the signing key")
-	cmd.Flags().StringVarP(&certPath, "certificate", "c", "", "Path to the signing key's certificate")
+	cmd.Flags().StringVar(&certPath, "certificate", "", "Path to the signing key's certificate")
 	cmd.Flags().StringSliceVarP(&intermediatePaths, "intermediates", "i", []string{}, "Intermediates that link trust back to a root in the policy")
 	cmd.Flags().StringVar(&spiffePath, "spiffe-socket", "", "Path to the SPIFFE Workload API socket")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,10 +39,15 @@ func init() {
 	runCmd.Flags().StringVarP(&stepName, "step", "s", "", "Name of the step being run")
 	runCmd.Flags().StringVarP(&rekorServer, "rekor-server", "r", "", "Rekor server to store attestations")
 	runCmd.Flags().BoolVar(&tracing, "trace", false, "enable tracing for the command")
-	runCmd.MarkFlagRequired("step")
+	cobra.OnInitialize(initConfig)
+
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
+	if stepName == "" {
+		return fmt.Errorf("step name is required")
+	}
+
 	signer, err := loadSigner()
 	if err != nil {
 		return fmt.Errorf("failed to load signer: %w", err)

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,32 @@
+## Witness Configuration
+
+Witness looks for the configuration file `.witness.yaml` in the current directory.
+
+Any values in the configuration file will be overridden by the command line arguments.
+
+```yaml
+run:
+    attestations: stringSlice
+    certificate: string
+    intermediates: stringSlice
+    key: string
+    outfile: string
+    rekor-server: string
+    spiffe-socket: string
+    step: string
+    trace: bool
+    workingdir: string
+sign:
+    certificate: string
+    datatype: string
+    intermediates: stringSlice
+    key: string
+    outfile: string
+    spiffe-socket: string
+verify:
+    artifactfile: string
+    artifacthash: string
+    attestations: stringSlice
+    layout-key: string
+    policy: string
+```

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/gookit/color v1.5.0
 	github.com/sigstore/rekor v0.3.0
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
+	github.com/spf13/viper v1.9.0
 	github.com/spiffe/go-spiffe/v2 v2.0.0-beta.10
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210909193231-528a39cd75f3
@@ -75,8 +77,6 @@ require (
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.9.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 // indirect
 	github.com/theupdateframework/go-tuf v0.0.0-20211006142131-1dc15a86c64d // indirect


### PR DESCRIPTION
The PR add config file support for witness.  The goal of this PR is to reduce the friction of implementation. 

Few issues addressed in this PR:
- The certificate flag no longer has a short alias.  -c is generally the flag for config so I took it.
- I had to change how the step requirement was evaluated.

fixes #8 

