### PR TITLE
feat: add SBOM SPDX-JSON generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: 'v1.1.0'
+          version: 'v1.2.2'
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,8 +16,14 @@ builds:
       - amd64
       - arm64
     main: .
+gomod:
+  proxy: true
 source:
   enabled: true
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
 signs:
   - cmd: cosign
     signature: "${artifact}.sig"


### PR DESCRIPTION
This commit enables SPDX-JSON support in the goreleaser configuration. We will from now on create SBOM SPDX-JSON files for the source tarball and the archive tarballs.