### PR TITLE
fix(policy): fix verification with no rego policies

### DIFF
--- a/pkg/policy/rego.go
+++ b/pkg/policy/rego.go
@@ -45,6 +45,10 @@ func (e ErrPolicyDenied) Error() string {
 }
 
 func EvaluateRegoPolicy(attestor attestation.Attestor, policies []RegoPolicy) error {
+	if len(policies) == 0 {
+		return nil
+	}
+
 	attestorJson, err := json.Marshal(attestor)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes a bug that causes verification to inappropriately fail if no rego
policies are in the witness policy.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>