### PR TITLE
feat(attestors): add maven attestor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/testifysec/witness/pkg/attestation/git"
 	_ "github.com/testifysec/witness/pkg/attestation/gitlab"
 	_ "github.com/testifysec/witness/pkg/attestation/jwt"
+	_ "github.com/testifysec/witness/pkg/attestation/maven"
 )
 
 var keyPath string

--- a/pkg/attestation/maven/maven.go
+++ b/pkg/attestation/maven/maven.go
@@ -1,0 +1,125 @@
+// Copyright 2021 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maven
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/testifysec/witness/pkg/attestation"
+	"github.com/testifysec/witness/pkg/cryptoutil"
+)
+
+const (
+	Name = "Maven"
+	Type = "https://witness.testifysec.com/attestations/Maven/v0.1"
+)
+
+func init() {
+	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+		return New()
+	})
+}
+
+type Attestor struct {
+	XMLName      xml.Name          `xml:"project" json:"-"`
+	GroupId      string            `xml:"groupId" json:"groupid"`
+	ArtifactId   string            `xml:"artifactId" json:"artifactid"`
+	Version      string            `xml:"version" json:"version"`
+	ProjectName  string            `xml:"name" json:"projectname"`
+	Dependencies []MavenDependency `xml:"dependencies>dependency" json:"dependencies"`
+
+	pomPath  string
+	subjects map[string]cryptoutil.DigestSet
+}
+
+type MavenDependency struct {
+	GroupId    string `xml:"groupId" json:"groupid"`
+	ArtifactId string `xml:"artifactId" json:"artifactid"`
+	Version    string `xml:"version" json:"version"`
+	Scope      string `xml:"scope" json:"scope"`
+}
+
+type Option func(*Attestor)
+
+func WithPom(path string) Option {
+	return func(a *Attestor) {
+		a.pomPath = path
+	}
+}
+
+func New(opts ...Option) *Attestor {
+	attestor := &Attestor{
+		pomPath:  "pom.xml",
+		subjects: make(map[string]cryptoutil.DigestSet),
+	}
+
+	for _, opt := range opts {
+		opt(attestor)
+	}
+
+	return attestor
+}
+
+func (a *Attestor) Name() string {
+	return Name
+}
+
+func (a *Attestor) Type() string {
+	return Type
+}
+
+func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
+	pomFile, err := os.Open(a.pomPath)
+	if err != nil {
+		return err
+	}
+
+	defer pomFile.Close()
+	pomFileBytes, err := io.ReadAll(pomFile)
+	if err != nil {
+		return err
+	}
+
+	if err := xml.Unmarshal(pomFileBytes, &a); err != nil {
+		return err
+	}
+
+	hashes := ctx.Hashes()
+	projectSubject := fmt.Sprintf("mvn:%v/%v@%v", a.GroupId, a.ArtifactId, a.Version)
+	projectDigest, err := cryptoutil.CalculateDigestSetFromBytes([]byte(projectSubject), hashes)
+	if err != nil {
+		return err
+	}
+
+	a.subjects[projectSubject] = projectDigest
+	for _, dep := range a.Dependencies {
+		depSubject := fmt.Sprintf("mvn:%v/%v@%v", dep.GroupId, dep.ArtifactId, dep.Version)
+		depDigest, err := cryptoutil.CalculateDigestSetFromBytes([]byte(depSubject), hashes)
+		if err != nil {
+			return err
+		}
+
+		a.subjects[depSubject] = depDigest
+	}
+
+	return nil
+}
+
+func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
+	return a.subjects
+}

--- a/pkg/attestation/maven/maven_test.go
+++ b/pkg/attestation/maven/maven_test.go
@@ -1,0 +1,133 @@
+// Copyright 2021 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maven
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testifysec/witness/pkg/attestation"
+)
+
+func writeTempPomXml(t *testing.T) (string, error) {
+	tmpDir := t.TempDir()
+	pomPath := filepath.Join(tmpDir, "pom.xml")
+	file, err := os.Create(pomPath)
+	if err != nil {
+		return "", err
+	}
+
+	defer file.Close()
+	if _, err = file.Write([]byte(testPomXml)); err != nil {
+		return "", err
+	}
+
+	return pomPath, nil
+}
+
+func TestMaven(t *testing.T) {
+	pomPath, err := writeTempPomXml(t)
+	require.NoError(t, err)
+	attestor := New(WithPom(pomPath))
+	ctx, err := attestation.NewContext([]attestation.Attestor{attestor})
+	require.NoError(t, err)
+	err = ctx.RunAttestors()
+	assert.NoError(t, err)
+}
+
+const testPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>my-app</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>
+`


### PR DESCRIPTION
Adds a maven attestor that will read a provided pom.xml file and record
the dependencies of the project being built.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>