### PR TITLE
Lifecycle support

### DIFF
--- a/cmd/options/run.go
+++ b/cmd/options/run.go
@@ -29,7 +29,7 @@ type RunOptions struct {
 func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	ro.KeyOptions.AddFlags(cmd)
 	cmd.Flags().StringVarP(&ro.WorkingDir, "workingdir", "d", "", "Directory that commands will be run from")
-	cmd.Flags().StringSliceVarP(&ro.Attestations, "attestations", "a", []string{"Environment", "Artifact", "Git"}, "Attestations to record")
+	cmd.Flags().StringSliceVarP(&ro.Attestations, "attestations", "a", []string{"environment", "git"}, "Attestations to record")
 	cmd.Flags().StringVarP(&ro.OutFilePath, "outfile", "o", "", "File to write signed data.  Defaults to stdout")
 	cmd.Flags().StringVarP(&ro.StepName, "step", "s", "", "Name of the step being run")
 	cmd.Flags().StringVarP(&ro.RekorServer, "rekor-server", "r", "", "Rekor server to store attestations")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,6 @@ import (
 	"github.com/testifysec/witness/pkg/spiffe"
 
 	// imported so their init functions run
-	_ "github.com/testifysec/witness/pkg/attestation/artifact"
 	_ "github.com/testifysec/witness/pkg/attestation/commandrun"
 	_ "github.com/testifysec/witness/pkg/attestation/environment"
 	_ "github.com/testifysec/witness/pkg/attestation/gcp-iit"

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -17,9 +17,10 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/testifysec/witness/cmd/options"
 	"io"
 	"os"
+
+	"github.com/testifysec/witness/cmd/options"
 
 	"github.com/spf13/cobra"
 	witness "github.com/testifysec/witness/pkg"
@@ -85,6 +86,5 @@ func runVerify(vo options.VerifyOptions, args []string) error {
 		defer file.Close()
 		attestationFiles = append(attestationFiles, file)
 	}
-
 	return policy.Verify(attestationFiles)
 }

--- a/docs/witness_run.md
+++ b/docs/witness_run.md
@@ -9,7 +9,7 @@ witness run [cmd] [flags]
 ### Options
 
 ```
-  -a, --attestations strings    Attestations to record (default [Environment,Artifact,Git])
+  -a, --attestations strings    Attestations to record (default [environment,git])
       --certificate string      Path to the signing key's certificate
   -h, --help                    help for run
   -i, --intermediates strings   Intermediates that link trust back to a root in the policy

--- a/pkg/attestation/collection.go
+++ b/pkg/attestation/collection.go
@@ -20,7 +20,7 @@ import (
 	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
-const CollectionType = "https://witness.testifysec.com/AttestationCollection/v0.1"
+const CollectionType = "https://witness.testifysec.com/attestation-collection/v0.1"
 
 type Collection struct {
 	Name         string                  `json:"name"`

--- a/pkg/attestation/commandrun/commandrun.go
+++ b/pkg/attestation/commandrun/commandrun.go
@@ -21,17 +21,17 @@ import (
 	"os/exec"
 
 	"github.com/testifysec/witness/pkg/attestation"
-	"github.com/testifysec/witness/pkg/attestation/artifact"
 	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 const (
-	Name = "CommandRun"
-	Type = "https://witness.testifysec.com/attestations/CommandRun/v0.1"
+	Name    = "command-run"
+	Type    = "https://witness.testifysec.com/attestations/command-run/v0.1"
+	RunType = attestation.Internal
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -85,12 +85,11 @@ type ProcessInfo struct {
 }
 
 type CommandRun struct {
-	Cmd       []string           `json:"cmd"`
-	Stdout    string             `json:"stdout,omitempty"`
-	Stderr    string             `json:"stderr,omitempty"`
-	ExitCode  int                `json:"exitcode"`
-	Products  *artifact.Attestor `json:"products"`
-	Processes []ProcessInfo      `json:"processes,omitempty"`
+	Cmd       []string      `json:"cmd"`
+	Stdout    string        `json:"stdout,omitempty"`
+	Stderr    string        `json:"stderr,omitempty"`
+	ExitCode  int           `json:"exitcode"`
+	Processes []ProcessInfo `json:"processes,omitempty"`
 
 	silent        bool
 	materials     map[string]cryptoutil.DigestSet
@@ -105,20 +104,11 @@ func (rc *CommandRun) Attest(ctx *attestation.AttestationContext) error {
 		}
 	}
 
-	if len(rc.materials) <= 0 {
-		for _, attestor := range ctx.CompletedAttestors() {
-			if artifactAttestor, ok := attestor.(*artifact.Attestor); ok {
-				rc.materials = artifactAttestor.Artifacts
-			}
-		}
-	}
-
 	if err := rc.runCmd(ctx); err != nil {
 		return err
 	}
 
-	rc.Products = artifact.New(artifact.WithBaseArtifacts(rc.materials))
-	return rc.Products.Attest(ctx)
+	return nil
 }
 
 func (rc *CommandRun) Name() string {
@@ -129,8 +119,8 @@ func (rc *CommandRun) Type() string {
 	return Type
 }
 
-func (rc *CommandRun) Subjects() map[string]cryptoutil.DigestSet {
-	return rc.Products.Artifacts
+func (rc *CommandRun) RunType() attestation.RunType {
+	return RunType
 }
 
 func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {

--- a/pkg/attestation/context.go
+++ b/pkg/attestation/context.go
@@ -19,6 +19,8 @@ import (
 	"crypto"
 	"fmt"
 	"os"
+
+	"github.com/testifysec/witness/pkg/cryptoutil"
 )
 
 type ErrInvalidOption struct {
@@ -26,8 +28,28 @@ type ErrInvalidOption struct {
 	Reason string
 }
 
+type ErrInternal struct {
+	Reason string
+}
+
+type RunType string
+
+const (
+	Internal    RunType = "internal"
+	PreRunType  RunType = "pre"
+	PostRunType RunType = "post"
+)
+
+func (r RunType) String() string {
+	return string(r)
+}
+
 func (e ErrInvalidOption) Error() string {
 	return fmt.Sprintf("invalid value for option %v: %v", e.Option, e.Reason)
+}
+
+func (e ErrInternal) Error() string {
+	return fmt.Sprintf("internal error: %v", e.Reason)
 }
 
 type AttestationContextOption func(ctx *AttestationContext)
@@ -60,9 +82,16 @@ type AttestationContext struct {
 	workingDir         string
 	hashes             []crypto.Hash
 	completedAttestors []Attestor
+	stepName           string
+	Products           map[string]cryptoutil.DigestSet
 }
 
-func NewContext(attestors []Attestor, opts ...AttestationContextOption) (*AttestationContext, error) {
+type Product struct {
+	MimeType string               `json:"mime_type"`
+	Digest   cryptoutil.DigestSet `json:"digest"`
+}
+
+func NewContext(stepName string, attestors []Attestor, opts ...AttestationContextOption) (*AttestationContext, error) {
 	if len(attestors) <= 0 {
 		return nil, ErrInvalidOption{
 			Option: "attestors",
@@ -80,6 +109,7 @@ func NewContext(attestors []Attestor, opts ...AttestationContextOption) (*Attest
 		attestors:  attestors,
 		workingDir: wd,
 		hashes:     []crypto.Hash{crypto.SHA256},
+		stepName:   stepName,
 	}
 
 	for _, opt := range opts {
@@ -90,14 +120,74 @@ func NewContext(attestors []Attestor, opts ...AttestationContextOption) (*Attest
 }
 
 func (ctx *AttestationContext) RunAttestors() error {
+	preAttestors := []Attestor{}
+	postAttestors := []Attestor{}
+	var cmdAttestor Attestor
+	var materialAttestor Attestor
+	var productAttestor Attestor
+
 	for _, attestor := range ctx.attestors {
+
+		switch attestor.RunType() {
+		case PreRunType:
+			preAttestors = append(preAttestors, attestor)
+
+		case Internal:
+			if attestor.Name() == "command-run" {
+				cmdAttestor = attestor
+			}
+			if attestor.Name() == "material" {
+				materialAttestor = attestor
+			}
+			if attestor.Name() == "product" {
+				productAttestor = attestor
+			}
+
+		case PostRunType:
+			postAttestors = append(postAttestors, attestor)
+
+		default:
+			return ErrInvalidOption{
+				Option: "attestor.RunType",
+				Reason: fmt.Sprintf("unknown run type %v", attestor.RunType()),
+			}
+		}
+	}
+
+	if materialAttestor == nil || productAttestor == nil || cmdAttestor == nil {
+		return ErrInternal{
+			Reason: "missing required attestors",
+		}
+	}
+
+	for _, attestor := range preAttestors {
 		if err := attestor.Attest(ctx); err != nil {
 			return err
 		}
-
 		ctx.completedAttestors = append(ctx.completedAttestors, attestor)
 	}
 
+	if err := materialAttestor.Attest(ctx); err != nil {
+		return err
+	}
+	ctx.completedAttestors = append(ctx.completedAttestors, materialAttestor)
+
+	if err := cmdAttestor.Attest(ctx); err != nil {
+		return err
+	}
+	ctx.completedAttestors = append(ctx.completedAttestors, cmdAttestor)
+
+	if err := productAttestor.Attest(ctx); err != nil {
+		return err
+	}
+	ctx.completedAttestors = append(ctx.completedAttestors, productAttestor)
+
+	for _, attestor := range postAttestors {
+		if err := attestor.Attest(ctx); err != nil {
+			return err
+		}
+		ctx.completedAttestors = append(ctx.completedAttestors, attestor)
+	}
 	return nil
 }
 
@@ -119,4 +209,38 @@ func (ctx *AttestationContext) Hashes() []crypto.Hash {
 
 func (ctx *AttestationContext) Context() context.Context {
 	return ctx.ctx
+}
+
+func (ctx *AttestationContext) GetMaterials() (map[string]cryptoutil.DigestSet, error) {
+	allMaterials := make(map[string]cryptoutil.DigestSet)
+
+	for _, attestor := range ctx.attestors {
+		materialer, ok := attestor.(Materialer)
+		if !ok {
+			continue
+		}
+
+		newMaterial := materialer.GetMaterials()
+		for artifact, digests := range newMaterial {
+			allMaterials[artifact] = digests
+		}
+	}
+	return allMaterials, nil
+}
+
+func (ctx *AttestationContext) GetProducts() (map[string]Product, error) {
+	allProducts := make(map[string]Product)
+
+	for _, attestor := range ctx.attestors {
+		producter, ok := attestor.(Producter)
+		if !ok {
+			continue
+		}
+
+		newProducts := producter.GetProducts()
+		for product, digests := range newProducts {
+			allProducts[product] = digests
+		}
+	}
+	return allProducts, nil
 }

--- a/pkg/attestation/environment/environment.go
+++ b/pkg/attestation/environment/environment.go
@@ -24,12 +24,13 @@ import (
 )
 
 const (
-	Name = "Environment"
-	Type = "https://witness.testifysec.com/attestations/Environment/v0.1"
+	Name    = "environment"
+	Type    = "https://witness.testifysec.com/attestations/environment/v0.1"
+	RunType = attestation.PreRunType
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -51,6 +52,10 @@ func (a *Attestor) Name() string {
 
 func (a *Attestor) Type() string {
 	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {

--- a/pkg/attestation/factory.go
+++ b/pkg/attestation/factory.go
@@ -23,16 +23,26 @@ import (
 var (
 	attestationsByName = map[string]AttestorFactory{}
 	attestationsByType = map[string]AttestorFactory{}
+	attestationsByRun  = map[string]AttestorFactory{}
 )
 
 type Attestor interface {
 	Name() string
 	Type() string
+	RunType() RunType
 	Attest(ctx *AttestationContext) error
 }
 
 type Subjecter interface {
 	Subjects() map[string]cryptoutil.DigestSet
+}
+
+type Materialer interface {
+	GetMaterials() map[string]cryptoutil.DigestSet
+}
+
+type Producter interface {
+	GetProducts() map[string]Product
 }
 
 type AttestorFactory func() Attestor
@@ -43,9 +53,10 @@ func (e ErrAttestationNotFound) Error() string {
 	return fmt.Sprintf("attestation not found: %v", string(e))
 }
 
-func RegisterAttestation(name, uri string, factoryFunc AttestorFactory) {
+func RegisterAttestation(name, uri string, run RunType, factoryFunc AttestorFactory) {
 	attestationsByName[name] = factoryFunc
 	attestationsByType[uri] = factoryFunc
+	attestationsByRun[run.String()] = factoryFunc
 }
 
 func FactoryByType(uri string) (AttestorFactory, bool) {

--- a/pkg/attestation/file/file.go
+++ b/pkg/attestation/file/file.go
@@ -12,82 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package artifact
+package file
 
 import (
 	"crypto"
-	"encoding/json"
 	"io/fs"
 	"path/filepath"
 
-	"github.com/testifysec/witness/pkg/attestation"
 	"github.com/testifysec/witness/pkg/cryptoutil"
 )
-
-const (
-	Name = "Artifact"
-	Type = "https://witness.testifysec.com/attestations/Artifact/v0.1"
-)
-
-func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
-		return New()
-	})
-}
-
-type Option func(*Attestor)
-
-func WithBaseArtifacts(baseArtifacts map[string]cryptoutil.DigestSet) Option {
-	return func(attestor *Attestor) {
-		attestor.baseArtifacts = baseArtifacts
-	}
-}
-
-type Attestor struct {
-	Artifacts     map[string]cryptoutil.DigestSet `json:"artifacts"`
-	baseArtifacts map[string]cryptoutil.DigestSet
-}
-
-func (a Attestor) Name() string {
-	return Name
-}
-
-func (a Attestor) Type() string {
-	return Type
-}
-
-func New(opts ...Option) *Attestor {
-	attestor := &Attestor{}
-	for _, opt := range opts {
-		opt(attestor)
-	}
-
-	return attestor
-}
-
-func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	artifacts, err := recordArtifacts(ctx.WorkingDir(), a.baseArtifacts, ctx.Hashes(), map[string]struct{}{})
-	if err != nil {
-		return err
-	}
-
-	a.Artifacts = artifacts
-	return nil
-}
-
-func (a *Attestor) MarshalJSON() ([]byte, error) {
-	return json.Marshal(a.Artifacts)
-}
-
-func (a *Attestor) UnmarshalJSON(data []byte) error {
-	attestations := make(map[string]cryptoutil.DigestSet)
-	return json.Unmarshal(data, &attestations)
-}
 
 // recordArtifacts will walk basePath and record the digests of each file with each of the functions in hashes.
 // If file already exists in baseArtifacts and the two artifacts are equal the artifact will not be in the
 // returned map of artifacts.
-func recordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []crypto.Hash, visitedSymlinks map[string]struct{}) (map[string]cryptoutil.DigestSet, error) {
+func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []crypto.Hash, visitedSymlinks map[string]struct{}) (map[string]cryptoutil.DigestSet, error) {
 	artifacts := make(map[string]cryptoutil.DigestSet)
 	err := filepath.Walk(basePath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -115,7 +53,7 @@ func recordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			}
 
 			visitedSymlinks[linkedPath] = struct{}{}
-			symlinkedArtifacts, err := recordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks)
+			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks)
 			if err != nil {
 				return err
 			}
@@ -153,6 +91,5 @@ func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[
 	if previous, ok := baseArtifacts[path]; ok && artifact.Equal(previous) {
 		return false
 	}
-
 	return true
 }

--- a/pkg/attestation/gcp-iit/gcp-iit.go
+++ b/pkg/attestation/gcp-iit/gcp-iit.go
@@ -31,7 +31,9 @@ import (
 
 const (
 	Name    = "gcp-iit"
-	Type    = "https://witness.testifysec.com/attestation/gcp-iit/v0.0.1"
+	Type    = "https://witness.testifysec.com/attestation/gcp-iit/v0.1"
+	RunType = attestation.PreRunType
+
 	jwksUrl = "https://www.googleapis.com/oauth2/v3/certs"
 
 	defaultIdentityTokenHost     = "metadata.google.internal"
@@ -45,7 +47,7 @@ const (
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -86,6 +88,10 @@ func (a *Attestor) Name() string {
 
 func (a *Attestor) Type() string {
 	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {

--- a/pkg/attestation/git/git.go
+++ b/pkg/attestation/git/git.go
@@ -24,12 +24,13 @@ import (
 )
 
 const (
-	Name = "Git"
-	Type = "https://witness.testifysec.com/attestations/Git/v0.1"
+	Name    = "git"
+	Type    = "https://witness.testifysec.com/attestations/git/v0.1"
+	RunType = attestation.PreRunType
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -56,6 +57,10 @@ func (a *Attestor) Name() string {
 
 func (a *Attestor) Type() string {
 	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {

--- a/pkg/attestation/gitlab/gitlab.go
+++ b/pkg/attestation/gitlab/gitlab.go
@@ -23,13 +23,15 @@ import (
 )
 
 const (
-	Name    = "Gitlab"
-	Type    = "https://witness.testifysec.com/attestations/Gitlab/v0.1"
+	Name    = "gitlab"
+	Type    = "https://witness.testifysec.com/attestations/gitlab/v0.1"
+	RunType = attestation.PreRunType
+
 	jwksUrl = "https://gitlab.com/-/jwks"
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -70,6 +72,10 @@ func (a *Attestor) Name() string {
 
 func (a *Attestor) Type() string {
 	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {

--- a/pkg/attestation/jwt/jwt.go
+++ b/pkg/attestation/jwt/jwt.go
@@ -25,12 +25,13 @@ import (
 )
 
 const (
-	Name = "JWT"
-	Type = "https://witness.testifysec.com/attestations/JWT/v0.1"
+	Name    = "jwt"
+	Type    = "https://witness.testifysec.com/attestations/jwt/v0.1"
+	RunType = attestation.PreRunType
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -132,4 +133,8 @@ func (a *Attestor) Name() string {
 
 func (a *Attestor) Type() string {
 	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
 }

--- a/pkg/attestation/material/material.go
+++ b/pkg/attestation/material/material.go
@@ -1,0 +1,74 @@
+// Copyright 2021 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package material
+
+import (
+	"github.com/testifysec/witness/pkg/attestation"
+	"github.com/testifysec/witness/pkg/attestation/file"
+	"github.com/testifysec/witness/pkg/cryptoutil"
+)
+
+const (
+	Name    = "material"
+	Type    = "https://witness.testifysec.com/attestations/material/v0.1"
+	RunType = attestation.Internal
+)
+
+func init() {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+		return New()
+	})
+}
+
+type Option func(*Attestor)
+
+type Attestor struct {
+	Materials map[string]cryptoutil.DigestSet `json:"materials"`
+}
+
+func (a Attestor) Name() string {
+	return Name
+}
+
+func (a Attestor) Type() string {
+	return Type
+}
+
+func (rc *Attestor) RunType() attestation.RunType {
+	return RunType
+}
+
+func New(opts ...Option) *Attestor {
+	attestor := &Attestor{}
+	for _, opt := range opts {
+		opt(attestor)
+	}
+
+	return attestor
+}
+
+func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
+	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{})
+	if err != nil {
+		return err
+	}
+
+	a.Materials = materials
+	return nil
+}
+
+func (a *Attestor) GetMaterials() map[string]cryptoutil.DigestSet {
+	return a.Materials
+}

--- a/pkg/attestation/maven/maven.go
+++ b/pkg/attestation/maven/maven.go
@@ -25,12 +25,13 @@ import (
 )
 
 const (
-	Name = "Maven"
-	Type = "https://witness.testifysec.com/attestations/Maven/v0.1"
+	Name    = "maven"
+	Type    = "https://witness.testifysec.com/attestations/maven/v0.1"
+	RunType = attestation.PreRunType
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -81,6 +82,10 @@ func (a *Attestor) Name() string {
 
 func (a *Attestor) Type() string {
 	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {

--- a/pkg/attestation/maven/maven_test.go
+++ b/pkg/attestation/maven/maven_test.go
@@ -44,9 +44,9 @@ func TestMaven(t *testing.T) {
 	pomPath, err := writeTempPomXml(t)
 	require.NoError(t, err)
 	attestor := New(WithPom(pomPath))
-	ctx, err := attestation.NewContext([]attestation.Attestor{attestor})
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
 	require.NoError(t, err)
-	err = ctx.RunAttestors()
+	err = attestor.Attest(ctx)
 	assert.NoError(t, err)
 }
 

--- a/pkg/attestation/product/product.go
+++ b/pkg/attestation/product/product.go
@@ -1,0 +1,132 @@
+// Copyright 2021 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package product
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/testifysec/witness/pkg/attestation"
+	"github.com/testifysec/witness/pkg/attestation/file"
+	"github.com/testifysec/witness/pkg/cryptoutil"
+)
+
+const (
+	Name    = "product"
+	Type    = "https://witness.testifysec.com/attestations/product/v0.1"
+	RunType = attestation.Internal
+)
+
+func init() {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+		return New()
+	})
+}
+
+type Option func(*Attestor)
+
+type Attestor struct {
+	Products      map[string]attestation.Product `json:"products"`
+	baseArtifacts map[string]cryptoutil.DigestSet
+}
+
+func fromDigestMap(digestMap map[string]cryptoutil.DigestSet) map[string]attestation.Product {
+	products := make(map[string]attestation.Product)
+	for fileName, digestSet := range digestMap {
+
+		mimeType := "unknown"
+
+		f, err := os.OpenFile(fileName, os.O_RDONLY, 0666)
+		if err == nil {
+			mimeType, err = getFileContentType(f)
+			if err != nil {
+				mimeType = "unknown"
+			}
+			f.Close()
+		}
+		defer f.Close()
+
+		products[fileName] = attestation.Product{
+			MimeType: mimeType,
+			Digest:   digestSet,
+		}
+	}
+	return products
+}
+
+func (a Attestor) Name() string {
+	return Name
+}
+
+func (a Attestor) Type() string {
+	return Type
+}
+
+func (rc *Attestor) RunType() attestation.RunType {
+	return RunType
+}
+
+func New(opts ...Option) *Attestor {
+	attestor := &Attestor{}
+	for _, opt := range opts {
+		opt(attestor)
+	}
+
+	return attestor
+}
+
+func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
+
+	baseArtifacts, err := ctx.GetMaterials()
+	if err != nil {
+		return err
+	}
+
+	a.baseArtifacts = baseArtifacts
+
+	products, err := file.RecordArtifacts(ctx.WorkingDir(), a.baseArtifacts, ctx.Hashes(), map[string]struct{}{})
+	if err != nil {
+		return err
+	}
+
+	a.Products = fromDigestMap(products)
+	return nil
+}
+
+func (a *Attestor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.Products)
+}
+
+func (a *Attestor) GetProducts() map[string]attestation.Product {
+	return a.Products
+}
+
+func getFileContentType(file *os.File) (string, error) {
+
+	// Only the first 512 bytes are used to sniff the content type.
+	buffer := make([]byte, 512)
+
+	_, err := file.Read(buffer)
+	if err != nil {
+		return "", err
+	}
+
+	// Use the net/http package's handy DectectContentType function. Always returns a valid
+	// content-type by returning "application/octet-stream" if no others seemed to match.
+	contentType := http.DetectContentType(buffer)
+
+	return contentType, nil
+}

--- a/pkg/attestation/product/product_test.go
+++ b/pkg/attestation/product/product_test.go
@@ -1,0 +1,89 @@
+// Copyright 2021 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package product
+
+import (
+	"crypto"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+	"github.com/testifysec/witness/pkg/attestation"
+	"github.com/testifysec/witness/pkg/cryptoutil"
+)
+
+func Test_fromDigestMap(t *testing.T) {
+
+	testDigest, err := cryptoutil.CalculateDigestSetFromBytes([]byte("test"), []crypto.Hash{crypto.SHA256})
+	if err != nil {
+		t.Errorf("Failed to calculate digest set from bytes: %v", err)
+	}
+
+	testDigestSet := make(map[string]cryptoutil.DigestSet)
+	testDigestSet["test"] = testDigest
+
+	result := fromDigestMap(testDigestSet)
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 product, got %d", len(result))
+	}
+
+	if result["test"].Digest.Equal(testDigest) == false {
+		t.Errorf("Expected digest set to be %v, got %v", testDigest, result["test"])
+	}
+
+	t.Logf("Result: %v", spew.Sdump(result["test"]))
+	t.Logf("Expected: %v", spew.Sdump(testDigest))
+}
+
+func TestAttestor_Name(t *testing.T) {
+	a := New()
+	if a.Name() != Name {
+		t.Errorf("Expected Name to be %s, got %s", Name, a.Name())
+	}
+}
+
+func TestAttestor_Type(t *testing.T) {
+	a := New()
+	if a.Type() != Type {
+		t.Errorf("Expected Type to be %s, got %s", Type, a.Type())
+	}
+}
+
+func TestAttestor_RunType(t *testing.T) {
+	a := New()
+	if a.RunType() != RunType {
+		t.Errorf("Expected RunType to be %s, got %s", RunType, a.RunType())
+	}
+}
+
+func TestAttestor_Attest(t *testing.T) {
+	a := New()
+
+	testDigest, err := cryptoutil.CalculateDigestSetFromBytes([]byte("test"), []crypto.Hash{crypto.SHA256})
+	if err != nil {
+		t.Errorf("Failed to calculate digest set from bytes: %v", err)
+	}
+
+	testDigestSet := make(map[string]cryptoutil.DigestSet)
+	testDigestSet["test"] = testDigest
+
+	a.baseArtifacts = testDigestSet
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{a})
+	require.NoError(t, err)
+	err = a.Attest(ctx)
+	require.NoError(t, err)
+}

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -300,6 +300,10 @@ func (p Policy) verifyCollections(signedCollections []io.Reader) (map[string][]a
 					}
 
 					verifier, err := cryptoutil.NewX509Verifier(cert, intermediates, []*x509.Certificate{bundle.root})
+					if err != nil {
+						continue
+					}
+
 					functionaries = append(functionaries, verifier)
 				}
 			}

--- a/test/policy.json
+++ b/test/policy.json
@@ -6,11 +6,15 @@
         "name": "build",
         "attestations": [
           {
-            "type": "https://witness.testifysec.com/attestations/Artifact/v0.1",
+            "type": "https://witness.testifysec.com/attestations/material/v0.1",
             "policies": []
           },
           {
-            "type": "https://witness.testifysec.com/attestations/CommandRun/v0.1",
+            "type": "https://witness.testifysec.com/attestations/command-run/v0.1",
+            "policies": []
+          },
+          {
+            "type": "https://witness.testifysec.com/attestations/product/v0.1",
             "policies": []
           }
         ],

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -16,7 +16,7 @@ run:
     key: testkey.pem
     outfile: test-attestation.json
     step: build
-    trace: true
+    trace: false
 sign:
     key: testkey.pem
     outfile: policy-signed.json


### PR DESCRIPTION
This PR adds support for defining when attestors should run.  As a part of this PR we
break artifacts into materials and products and make their values available through
the attestor context.

fixes #95 
fixes #71 