### PR TITLE
fix: use a flag instead of argument in verify command.

### DIFF
--- a/cmd/options/sign.go
+++ b/cmd/options/sign.go
@@ -20,10 +20,12 @@ type SignOptions struct {
 	KeyOptions  KeyOptions
 	DataType    string
 	OutFilePath string
+	InFilePath  string
 }
 
 func (so *SignOptions) AddFlags(cmd *cobra.Command) {
 	so.KeyOptions.AddFlags(cmd)
 	cmd.Flags().StringVarP(&so.DataType, "datatype", "t", "https://witness.testifysec.com/policy/v0.1", "The URI reference to the type of data being signed. Defaults to the Witness policy type")
 	cmd.Flags().StringVarP(&so.OutFilePath, "outfile", "o", "", "File to write signed data. Defaults to stdout")
+	cmd.Flags().StringVarP(&so.InFilePath, "infile", "f", "", "Witness policy file to sign")
 }

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -16,8 +16,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/testifysec/witness/cmd/options"
 	"os"
+
+	"github.com/testifysec/witness/cmd/options"
 
 	"github.com/spf13/cobra"
 	witness "github.com/testifysec/witness/pkg"
@@ -33,9 +34,8 @@ func SignCmd() *cobra.Command {
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSign(so, args)
+			return runSign(so)
 		},
-		Args: cobra.ExactArgs(1),
 	}
 
 	so.AddFlags(cmd)
@@ -44,14 +44,13 @@ func SignCmd() *cobra.Command {
 
 //todo: this logic should be broken out and moved to pkg/
 //we need to abstract where keys are coming from, etc
-func runSign(so options.SignOptions, args []string) error {
+func runSign(so options.SignOptions) error {
 	signer, err := loadSigner(so.KeyOptions.SpiffePath, so.KeyOptions.KeyPath, so.KeyOptions.CertPath, so.KeyOptions.IntermediatePaths)
 	if err != nil {
 		return err
 	}
 
-	inFilePath := args[0]
-	inFile, err := os.Open(inFilePath)
+	inFile, err := os.Open(so.InFilePath)
 	if err != nil {
 		return fmt.Errorf("could not open file to sign: %v", err)
 	}

--- a/docs/witness_sign.md
+++ b/docs/witness_sign.md
@@ -16,6 +16,7 @@ witness sign [file] [flags]
       --certificate string      Path to the signing key's certificate
   -t, --datatype string         The URI reference to the type of data being signed. Defaults to the Witness policy type (default "https://witness.testifysec.com/policy/v0.1")
   -h, --help                    help for sign
+  -f, --infile string           Witness policy file to sign
   -i, --intermediates strings   Intermediates that link trust back to a root in the policy
   -k, --key string              Path to the signing key
   -o, --outfile string          File to write signed data. Defaults to stdout


### PR DESCRIPTION
BREAKING CHANGE: changes in sign cli.
fixes #69 