### PR TITLE
bug: fix config file not properly being applied

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,24 +20,24 @@ import (
 	"log"
 	"os"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/testifysec/witness/cmd/options"
 )
 
-func initConfig() {
+func initConfig(rootCmd *cobra.Command, rootOptions *options.RootOptions) {
 	v := viper.New()
-	rootCmd := New()
-	config := ro.Config
-	if _, err := os.Stat(config); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat(rootOptions.Config); errors.Is(err, os.ErrNotExist) {
 		if rootCmd.Flags().Lookup("config").Changed {
-			log.Fatalf("config file %s does not exist", config)
+			log.Fatalf("config file %s does not exist", rootOptions.Config)
 		} else {
-			log.Printf("%s does not exist, using command line arguments", config)
+			log.Printf("%s does not exist, using command line arguments", rootOptions.Config)
 			return
 		}
 	}
 
-	v.SetConfigFile(config)
+	v.SetConfigFile(rootOptions.Config)
 
 	if v.ConfigFileUsed() != "" {
 		log.Println("Using config file:", v.ConfigFileUsed())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(VerifyCmd())
 	cmd.AddCommand(RunCmd())
 	cmd.AddCommand(CompletionCmd())
+	cobra.OnInitialize(func() { initConfig(cmd, ro) })
 	return cmd
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,9 +41,8 @@ func RunCmd() *cobra.Command {
 		},
 		Args: cobra.ArbitraryArgs,
 	}
-	cobra.OnInitialize(initConfig)
+
 	o.AddFlags(cmd)
-	cmd.MarkFlagRequired("step")
 	return cmd
 }
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 ../bin/witness -c test.yaml run -- go build -o=testapp .
-../bin/witness -c test.yaml sign policy.json
+../bin/witness -c test.yaml sign -f policy.json
 ../bin/witness -c test.yaml verify


### PR DESCRIPTION
Some changes in how we create cobra commands resulted in options from
config files not properly being applied.  Since the initConfig function
was creating a new RootCmd it was not using the RootCmd that Cobra was
executing, which caused panics while trying to read the config option.