### PR TITLE
feat: standardize logging output

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,55 +17,53 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/testifysec/witness/cmd/options"
+	"github.com/testifysec/witness/pkg/log"
 )
 
-func initConfig(rootCmd *cobra.Command, rootOptions *options.RootOptions) {
+func initConfig(rootCmd *cobra.Command, rootOptions *options.RootOptions) error {
 	v := viper.New()
 	if _, err := os.Stat(rootOptions.Config); errors.Is(err, os.ErrNotExist) {
 		if rootCmd.Flags().Lookup("config").Changed {
-			log.Fatalf("config file %s does not exist", rootOptions.Config)
+			return fmt.Errorf("config file %s does not exist", rootOptions.Config)
 		} else {
-			log.Printf("%s does not exist, using command line arguments", rootOptions.Config)
-			return
+			log.Debugf("%s does not exist, using command line arguments", rootOptions.Config)
+			return nil
 		}
 	}
 
 	v.SetConfigFile(rootOptions.Config)
-
 	if v.ConfigFileUsed() != "" {
-		log.Println("Using config file:", v.ConfigFileUsed())
+		log.Infof("Using config file: %v", v.ConfigFileUsed())
 	}
 
 	if err := v.ReadInConfig(); err != nil {
-		log.Fatalf("Error reading config file: %s", err)
+		return fmt.Errorf("failed to read config file: %s", err)
 	}
 
 	//Currently we do not accept configuration for root commands
 	commands := rootCmd.Commands()
-
 	for _, cm := range commands {
 		//Check which command we are running
 		if !contains(os.Args, cm.Name()) {
 			continue
 		}
+
 		flags := cm.Flags()
 		flags.VisitAll(func(f *pflag.Flag) {
 			configKey := fmt.Sprintf("%s.%s", cm.Name(), f.Name)
-
 			if !f.Changed {
 				if f.Value.Type() == "stringSlice" {
 					configValue := v.GetStringSlice(configKey)
 					if len(configValue) > 0 {
 						for _, v := range configValue {
 							if err := f.Value.Set(v); err != nil {
-								log.Fatalf("Error setting config value: %s", err)
+								log.Errorf("failed to set config value: %s", err)
 							}
 						}
 					}
@@ -73,7 +71,7 @@ func initConfig(rootCmd *cobra.Command, rootOptions *options.RootOptions) {
 					configValue := v.GetString(configKey)
 					if configValue != "" {
 						if err := f.Value.Set(configValue); err != nil {
-							log.Fatalf("Error setting config value: %s", err)
+							log.Errorf("failed to set config value: %s", err)
 						}
 					}
 				}
@@ -81,6 +79,7 @@ func initConfig(rootCmd *cobra.Command, rootOptions *options.RootOptions) {
 		})
 	}
 
+	return nil
 }
 
 func contains(s []string, str string) bool {

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,0 +1,80 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+type logrusLogger struct {
+	l *logrus.Logger
+}
+
+func newLogger() *logrusLogger {
+	l := logrus.New()
+	l.Out = os.Stderr
+	f := &logrus.TextFormatter{
+		DisableLevelTruncation: true,
+		PadLevelText:           true,
+		DisableTimestamp:       true,
+	}
+
+	l.SetFormatter(f)
+	return &logrusLogger{l}
+}
+
+func (l *logrusLogger) SetLevel(levelStr string) error {
+	level, err := logrus.ParseLevel(levelStr)
+	if err != nil {
+		return err
+	}
+
+	l.l.SetLevel(level)
+	return nil
+}
+
+func (l *logrusLogger) Errorf(format string, args ...interface{}) {
+	l.l.Errorf(format, args...)
+}
+
+func (l *logrusLogger) Error(args ...interface{}) {
+	l.l.Error(args...)
+}
+
+func (l *logrusLogger) Warnf(format string, args ...interface{}) {
+	l.l.Warnf(format, args...)
+}
+
+func (l *logrusLogger) Warn(args ...interface{}) {
+	l.l.Warn(args...)
+}
+
+func (l *logrusLogger) Debugf(format string, args ...interface{}) {
+	l.l.Debugf(format, args...)
+}
+
+func (l *logrusLogger) Debug(args ...interface{}) {
+	l.l.Debug(args...)
+}
+
+func (l *logrusLogger) Infof(format string, args ...interface{}) {
+	l.l.Infof(format, args...)
+}
+
+func (l *logrusLogger) Info(args ...interface{}) {
+	l.l.Info(args...)
+}

--- a/cmd/options/root.go
+++ b/cmd/options/root.go
@@ -17,9 +17,11 @@ package options
 import "github.com/spf13/cobra"
 
 type RootOptions struct {
-	Config string
+	Config   string
+	LogLevel string
 }
 
 func (ro *RootOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&ro.Config, "config", "c", ".witness.yaml", "Path to the witness config file")
+	cmd.PersistentFlags().StringVarP(&ro.LogLevel, "log-level", "l", "info", "Level of logging to output (debug, info, warn, error)")
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/testifysec/witness/pkg/attestation/material"
 	"github.com/testifysec/witness/pkg/attestation/product"
 	"github.com/testifysec/witness/pkg/intoto"
+	"github.com/testifysec/witness/pkg/log"
 	"github.com/testifysec/witness/pkg/rekor"
 )
 
@@ -141,7 +142,7 @@ func runRun(ro options.RunOptions, args []string) error {
 			return fmt.Errorf("failed to store artifact in rekor: %w", err)
 		}
 
-		fmt.Printf("Rekor entry added at %v%v\n", rekorServer, resp.Location)
+		log.Infof("Rekor entry added at %v%v\n", rekorServer, resp.Location)
 	}
 
 	return nil

--- a/docs/witness.md
+++ b/docs/witness.md
@@ -5,8 +5,9 @@ Collect and verify attestations about your build environments
 ### Options
 
 ```
-  -c, --config string   Path to the witness config file (default ".witness.yaml")
-  -h, --help            help for witness
+  -c, --config string      Path to the witness config file (default ".witness.yaml")
+  -h, --help               help for witness
+  -l, --log-level string   Level of logging to output (debug, info, warn, error) (default "info")
 ```
 
 ### SEE ALSO

--- a/docs/witness_completion.md
+++ b/docs/witness_completion.md
@@ -43,7 +43,8 @@ witness completion [bash|zsh|fish|powershell]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the witness config file (default ".witness.yaml")
+  -c, --config string      Path to the witness config file (default ".witness.yaml")
+  -l, --log-level string   Level of logging to output (debug, info, warn, error) (default "info")
 ```
 
 ### SEE ALSO

--- a/docs/witness_run.md
+++ b/docs/witness_run.md
@@ -25,7 +25,8 @@ witness run [cmd] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the witness config file (default ".witness.yaml")
+  -c, --config string      Path to the witness config file (default ".witness.yaml")
+  -l, --log-level string   Level of logging to output (debug, info, warn, error) (default "info")
 ```
 
 ### SEE ALSO

--- a/docs/witness_sign.md
+++ b/docs/witness_sign.md
@@ -26,7 +26,8 @@ witness sign [file] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the witness config file (default ".witness.yaml")
+  -c, --config string      Path to the witness config file (default ".witness.yaml")
+  -l, --log-level string   Level of logging to output (debug, info, warn, error) (default "info")
 ```
 
 ### SEE ALSO

--- a/docs/witness_verify.md
+++ b/docs/witness_verify.md
@@ -24,7 +24,8 @@ witness verify [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string   Path to the witness config file (default ".witness.yaml")
+  -c, --config string      Path to the witness config file (default ".witness.yaml")
+  -l, --log-level string   Level of logging to output (debug, info, warn, error) (default "info")
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-openapi/runtime v0.21.0
-	github.com/gookit/color v1.5.0
 	github.com/open-policy-agent/opa v0.35.0
 	github.com/sigstore/rekor v0.4.0
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.10.1
@@ -84,7 +84,6 @@ require (
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b // indirect
 	github.com/zeebo/errs v1.2.2 // indirect
 	go.mongodb.org/mongo-driver v1.7.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -878,8 +878,6 @@ github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pf
 github.com/googleapis/gax-go/v2 v2.1.1 h1:dp3bWCh+PPO1zjRRiCSczJav13sBvG4UhNyVTa1KqdU=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
-github.com/gookit/color v1.5.0 h1:1Opow3+BWDwqor78DcJkJCIwnkviFi+rrOANki9BUFw=
-github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/goreleaser/goreleaser v0.134.0/go.mod h1:ZT6Y2rSYa6NxQzIsdfWWNWAlYGXGbreo66NmE+3X3WQ=
@@ -1396,6 +1394,7 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -1533,8 +1532,6 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
-github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b h1:vVRagRXf67ESqAb72hG2C/ZwI8NtJF2u2V76EsuOHGY=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b/go.mod h1:HptNXiXVDcJjXe9SqMd0v2FsL9f8dz4GnXgltU6q/co=

--- a/pkg/attestation/commandrun/tracing_linux.go
+++ b/pkg/attestation/commandrun/tracing_linux.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/testifysec/witness/pkg/attestation"
 	"github.com/testifysec/witness/pkg/cryptoutil"
+	"github.com/testifysec/witness/pkg/log"
 	"golang.org/x/sys/unix"
 )
 
@@ -107,10 +108,14 @@ func (p *ptraceContext) runTrace() error {
 		isPtraceTrap := (unix.SIGTRAP | unix.PTRACE_EVENT_STOP) == sig
 		if status.Stopped() && isPtraceTrap {
 			injectedSig = 0
-			_ = p.nextSyscall(pid)
+			if err := p.nextSyscall(pid); err != nil {
+				log.Debugf("(tracing) got error while processing syscall: %v", err)
+			}
 		}
 
-		_ = unix.PtraceSyscall(pid, injectedSig)
+		if err := unix.PtraceSyscall(pid, injectedSig); err != nil {
+			log.Debugf("(tracing) got error from ptrace syscall: %v", err)
+		}
 	}
 }
 

--- a/pkg/attestation/context.go
+++ b/pkg/attestation/context.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/testifysec/witness/pkg/cryptoutil"
+	"github.com/testifysec/witness/pkg/log"
 )
 
 type ErrInvalidOption struct {
@@ -127,7 +128,6 @@ func (ctx *AttestationContext) RunAttestors() error {
 	var productAttestor Attestor
 
 	for _, attestor := range ctx.attestors {
-
 		switch attestor.RunType() {
 		case PreRunType:
 			preAttestors = append(preAttestors, attestor)
@@ -161,6 +161,7 @@ func (ctx *AttestationContext) RunAttestors() error {
 	}
 
 	for _, attestor := range preAttestors {
+		log.Infof("Starting %v attestor...", attestor.Name())
 		if err := attestor.Attest(ctx); err != nil {
 			return err
 		}
@@ -168,21 +169,25 @@ func (ctx *AttestationContext) RunAttestors() error {
 	}
 
 	if err := materialAttestor.Attest(ctx); err != nil {
+		log.Infof("Starting %v attestor...", materialAttestor.Name())
 		return err
 	}
 	ctx.completedAttestors = append(ctx.completedAttestors, materialAttestor)
 
 	if err := cmdAttestor.Attest(ctx); err != nil {
+		log.Infof("Starting %v attestor...", cmdAttestor.Name())
 		return err
 	}
 	ctx.completedAttestors = append(ctx.completedAttestors, cmdAttestor)
 
 	if err := productAttestor.Attest(ctx); err != nil {
+		log.Infof("Starting %v attestor...", productAttestor.Name())
 		return err
 	}
 	ctx.completedAttestors = append(ctx.completedAttestors, productAttestor)
 
 	for _, attestor := range postAttestors {
+		log.Infof("Starting %v attestor...", attestor.Name())
 		if err := attestor.Attest(ctx); err != nil {
 			return err
 		}

--- a/pkg/attestation/gcp-iit/gcp-iit.go
+++ b/pkg/attestation/gcp-iit/gcp-iit.go
@@ -21,12 +21,12 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/testifysec/witness/pkg/cryptoutil"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/testifysec/witness/pkg/attestation"
 	"github.com/testifysec/witness/pkg/attestation/jwt"
+	"github.com/testifysec/witness/pkg/cryptoutil"
+	"github.com/testifysec/witness/pkg/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -180,7 +180,7 @@ func (a *Attestor) getInstanceData() {
 	for k, v := range endpoints {
 		data, err := getMetadata(v)
 		if err != nil {
-			fmt.Println(err)
+			log.Warnf("failed to retrieve gcp metadata from %v: %v", v, err)
 			continue
 		}
 		metadata[k] = string(data)
@@ -195,7 +195,7 @@ func (a *Attestor) getInstanceData() {
 
 	projID, projNum, err := parseJWTProjectInfo(a.JWT)
 	if err != nil {
-		fmt.Printf("unable to parse JWT project info: %v\n", err)
+		log.Warnf("unable to parse gcp project info from JWT: %v\n", err)
 	}
 
 	a.ProjectID = projID

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+var log Logger = SilentLogger{}
+
+// Logger is used by witness library code to print out relevant information at runtime.
+type Logger interface {
+	Errorf(format string, args ...interface{})
+	Error(args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warn(args ...interface{})
+	Debugf(format string, args ...interface{})
+	Debug(args ...interface{})
+	Infof(format string, args ...interface{})
+	Info(args ...interface{})
+}
+
+// SetLogger will set the Logger instance that all Witness library code will use as logging output.
+// The default is a SilentLogger that will output nothing.
+func SetLogger(l Logger) {
+	log = l
+}
+
+// GetLogger returns the Logger instance currently being used by Witness library code.
+func GetLogger() Logger {
+	return log
+}
+
+func Errorf(format string, args ...interface{}) {
+	log.Errorf(format, args...)
+}
+
+func Error(args ...interface{}) {
+	log.Error(args...)
+}
+
+func Warnf(format string, args ...interface{}) {
+	log.Warnf(format, args...)
+}
+
+func Warn(args ...interface{}) {
+	log.Warn(args...)
+}
+
+func Debugf(format string, args ...interface{}) {
+	log.Debugf(format, args...)
+}
+
+func Debug(args ...interface{}) {
+	log.Debug(args...)
+}
+
+func Infof(format string, args ...interface{}) {
+	log.Infof(format, args...)
+}
+
+func Info(args ...interface{}) {
+	log.Info(args...)
+}

--- a/pkg/log/silent.go
+++ b/pkg/log/silent.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+// SilentLogger is an implementation of the Logger interface that suppresses
+// all logging output. This is the default logger when using Witness as a
+// library, so that we don't interfere with the caller's stdout/stderr. Callers
+// should supply their own Logger to capture Witness logging if desired.
+type SilentLogger struct{}
+
+func (l SilentLogger) Errorf(format string, args ...interface{}) {}
+func (l SilentLogger) Error(args ...interface{})                 {}
+func (l SilentLogger) Warnf(format string, args ...interface{})  {}
+func (l SilentLogger) Warn(args ...interface{})                  {}
+func (l SilentLogger) Debugf(format string, args ...interface{}) {}
+func (l SilentLogger) Debug(args ...interface{})                 {}
+func (l SilentLogger) Infof(format string, args ...interface{})  {}
+func (l SilentLogger) Info(args ...interface{})                  {}


### PR DESCRIPTION
* Adds pkg/log library with logger interface
* Adds cmd/log.go with logrus implementation of above interface
  configured
* Logs errors that were being suppressed before and removes usage of log
  and fmt.Printf/Println in favor of using witness's logger.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>