### PR TITLE
refactor: standardize subject names

### DIFF
--- a/pkg/attestation/collection.go
+++ b/pkg/attestation/collection.go
@@ -16,6 +16,7 @@ package attestation
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/testifysec/witness/pkg/cryptoutil"
 )
@@ -83,7 +84,7 @@ func (c *Collection) Subjects() map[string]cryptoutil.DigestSet {
 		if subjecter, ok := collectionAttestation.Attestation.(Subjecter); ok {
 			subjects := subjecter.Subjects()
 			for subject, digest := range subjects {
-				allSubjects[subject] = digest
+				allSubjects[fmt.Sprintf("%v/%v", collectionAttestation.Type, subject)] = digest
 			}
 		}
 	}

--- a/pkg/attestation/gcp-iit/gcp-iit.go
+++ b/pkg/attestation/gcp-iit/gcp-iit.go
@@ -132,33 +132,31 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	if err != nil {
 		return err
 	}
-	a.subjects[a.InstanceID] = instanceIDSubject
+	a.subjects[fmt.Sprintf("instanceid:%v", a.InstanceID)] = instanceIDSubject
 
 	instanceHostnameSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.InstanceHostname), ctx.Hashes())
 	if err != nil {
 		return err
 	}
-	a.subjects[a.InstanceHostname] = instanceHostnameSubject
+	a.subjects[fmt.Sprintf("instancename:%v", a.InstanceHostname)] = instanceHostnameSubject
 
 	projectIDSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ProjectID), ctx.Hashes())
 	if err != nil {
 		return err
 	}
-	a.subjects[a.ProjectID] = projectIDSubject
+	a.subjects[fmt.Sprintf("projectid:%v", a.ProjectID)] = projectIDSubject
 
 	projectNumberSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ProjectNumber), ctx.Hashes())
 	if err != nil {
 		return err
 	}
+	a.subjects[fmt.Sprintf("projectnumber:%v", a.ProjectNumber)] = projectNumberSubject
 
-	a.subjects[a.ProjectNumber] = projectNumberSubject
-
-	clusterUIDSubejct, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ClusterUID), ctx.Hashes())
+	clusterUIDSubject, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ClusterUID), ctx.Hashes())
 	if err != nil {
 		return err
 	}
-
-	a.subjects[a.ClusterUID] = clusterUIDSubejct
+	a.subjects[fmt.Sprintf("clusteruid:%v", a.ClusterUID)] = clusterUIDSubject
 
 	return nil
 }

--- a/pkg/attestation/git/git.go
+++ b/pkg/attestation/git/git.go
@@ -105,7 +105,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 }
 
 func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
-	subjectName := fmt.Sprintf("git:%v", a.CommitHash)
+	subjectName := fmt.Sprintf("commithash:%v", a.CommitHash)
 	return map[string]cryptoutil.DigestSet{
 		subjectName: {
 			crypto.SHA1: a.CommitHash,

--- a/pkg/attestation/gitlab/gitlab.go
+++ b/pkg/attestation/gitlab/gitlab.go
@@ -15,6 +15,7 @@
 package gitlab
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/testifysec/witness/pkg/attestation"
@@ -109,13 +110,19 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		return err
 	}
 
-	a.subjects[a.PipelineUrl] = pipelineSubj
+	a.subjects[fmt.Sprintf("pipelineurl:%v", a.PipelineUrl)] = pipelineSubj
 	jobSubj, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.JobUrl), ctx.Hashes())
 	if err != nil {
 		return err
 	}
 
-	a.subjects[a.JobUrl] = jobSubj
+	a.subjects[fmt.Sprintf("joburl:%v", a.JobUrl)] = jobSubj
+	projectSubj, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.ProjectUrl), ctx.Hashes())
+	if err != nil {
+		return err
+	}
+
+	a.subjects[fmt.Sprintf("projecturl:%v", a.ProjectUrl)] = projectSubj
 	return nil
 }
 

--- a/pkg/attestation/maven/maven.go
+++ b/pkg/attestation/maven/maven.go
@@ -105,7 +105,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	}
 
 	hashes := ctx.Hashes()
-	projectSubject := fmt.Sprintf("mvn:%v/%v@%v", a.GroupId, a.ArtifactId, a.Version)
+	projectSubject := fmt.Sprintf("project:%v/%v@%v", a.GroupId, a.ArtifactId, a.Version)
 	projectDigest, err := cryptoutil.CalculateDigestSetFromBytes([]byte(projectSubject), hashes)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	a.subjects[projectSubject] = projectDigest
 	for _, dep := range a.Dependencies {
-		depSubject := fmt.Sprintf("mvn:%v/%v@%v", dep.GroupId, dep.ArtifactId, dep.Version)
+		depSubject := fmt.Sprintf("dependency:%v/%v@%v", dep.GroupId, dep.ArtifactId, dep.Version)
 		depDigest, err := cryptoutil.CalculateDigestSetFromBytes([]byte(depSubject), hashes)
 		if err != nil {
 			return err

--- a/pkg/attestation/product/product.go
+++ b/pkg/attestation/product/product.go
@@ -16,6 +16,7 @@ package product
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -107,7 +108,7 @@ func (a *Attestor) GetProducts() map[string]attestation.Product {
 func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	subjects := make(map[string]cryptoutil.DigestSet)
 	for productName, product := range a.Products {
-		subjects[productName] = product.Digest
+		subjects[fmt.Sprintf("file:%v", productName)] = product.Digest
 	}
 
 	return subjects


### PR DESCRIPTION
Refactors all the existing attestors to return their subjects as
`key:value`. The attestationCollection then prepends the attestor's type
to the subject to give the result:

```
"_type": "https://in-toto.io/Statement/v0.1",
"subject": [
  {
    "name": "https://witness.testifysec.com/attestations/git/v0.1/commithash:dde5c984a8ec35d5d93a8c6aac3ad2a0726d6427",
    "digest": {
      "sha1": "dde5c984a8ec35d5d93a8c6aac3ad2a0726d6427"
    }
  },
  {
    "name": "https://witness.testifysec.com/attestations/product/v0.1/file:testapp",
    "digest": {
      "sha256": "635ad310bea040e2cb95b50615880b5b52ac150df324d76f415ef27db46283dc"
    }
  }
]
```

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>