### PR TITLE
bug: fix go-releaser, add attestor option to Run from cmd

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
     goarch:
       - amd64
       - arm64
-    main: .
+    main: ./cmd/witness/
 gomod:
   proxy: true
 source:

--- a/cmd/witness/cmd/run.go
+++ b/cmd/witness/cmd/run.go
@@ -61,6 +61,7 @@ func runRun(ro options.RunOptions, args []string) error {
 		signer,
 		witness.RunWithTracing(ro.Tracing),
 		witness.RunWithCommand(args),
+		witness.RunWithAttestors(ro.Attestations),
 		witness.RunWithAttestationOpts(attestation.WithWorkingDir(ro.WorkingDir)),
 	)
 


### PR DESCRIPTION
Few lingering things from the refactor -- go-releaser needs to point to
the updated location of main.go and I forgot to pass the attestors
through to witness.Run.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>