### PR TITLE
feat: use rekor integrated time as a trusted time stamp

### DIFF
--- a/pkg/dsse/dsse.go
+++ b/pkg/dsse/dsse.go
@@ -20,6 +20,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/testifysec/witness/pkg/cryptoutil"
 )
@@ -111,6 +112,7 @@ type verificationOptions struct {
 	roots         []*x509.Certificate
 	intermediates []*x509.Certificate
 	verifiers     []cryptoutil.Verifier
+	trustedTime   time.Time
 }
 
 func WithRoots(roots []*x509.Certificate) VerificationOption {
@@ -128,6 +130,12 @@ func WithIntermediates(intermediates []*x509.Certificate) VerificationOption {
 func WithVerifiers(verifiers []cryptoutil.Verifier) VerificationOption {
 	return func(vo *verificationOptions) {
 		vo.verifiers = verifiers
+	}
+}
+
+func WithTrustedTime(time time.Time) VerificationOption {
+	return func(vo *verificationOptions) {
+		vo.trustedTime = time
 	}
 }
 
@@ -156,7 +164,7 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]cryptoutil.Verifier, err
 				continue
 			}
 
-			verifier, err := cryptoutil.NewX509Verifier(cert, options.intermediates, options.roots)
+			verifier, err := cryptoutil.NewX509Verifier(cert, options.intermediates, options.roots, options.trustedTime)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/rekor/rekor.go
+++ b/pkg/rekor/rekor.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-openapi/runtime"
 	"github.com/sigstore/rekor/pkg/client"
@@ -160,7 +161,7 @@ func ParseEnvelopeFromEntry(entry *models.LogEntryAnon) (dsse.Envelope, error) {
 			return env, fmt.Errorf("failed to decode signature: %w", err)
 		}
 
-		verifier, err := cryptoutil.NewVerifierFromReader(bytes.NewReader(sig.PublicKey))
+		verifier, err := cryptoutil.NewVerifierFromReader(bytes.NewReader(sig.PublicKey), cryptoutil.VerifyWithTrustedTime(time.Unix(*entry.IntegratedTime, 0)))
 		if err != nil {
 			return env, fmt.Errorf("failed to create verifier from public key on rekor entry: %w", err)
 		}


### PR DESCRIPTION
Uses the rekor entry's trusted timestamp as a trusted time when
evaluating signatures with a valid x509 certificate attached.

Fixes #115 

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>