### PR TITLE
bug: temporarily turn off go mod proxy

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,9 +15,9 @@ builds:
     goarch:
       - amd64
       - arm64
-    main: ./cmd/witness/
+    main: ./cmd/witness
 gomod:
-  proxy: true
+  proxy: false
 source:
   enabled: true
 sboms:


### PR DESCRIPTION
Until we turn the repository public go proxy won't work since we're
still private. This will be turned back on once the repo is switched
public.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>