### PR TITLE
feat: add algo hash list for digest calc in config

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"crypto"
 	"encoding/json"
 	"fmt"
 
@@ -102,12 +103,21 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 		}
 	}
 
+	var roHashes []crypto.Hash
+	for _, hashStr := range ro.Hashes {
+		hash, err := cryptoutil.HashFromString(hashStr)
+		if err != nil {
+			return fmt.Errorf("failed to parse hash: %w", err)
+		}
+		roHashes = append(roHashes, hash)
+	}
+
 	defer out.Close()
 	result, err := witness.Run(
 		ro.StepName,
 		signers[0],
 		witness.RunWithAttestors(attestors),
-		witness.RunWithAttestationOpts(attestation.WithWorkingDir(ro.WorkingDir)),
+		witness.RunWithAttestationOpts(attestation.WithWorkingDir(ro.WorkingDir), attestation.WithHashes(roHashes)),
 		witness.RunWithTimestampers(timestampers...),
 	)
 

--- a/docs/witness_run.md
+++ b/docs/witness_run.md
@@ -14,6 +14,7 @@ witness run [cmd] [flags]
       --attestor-product-exclude-glob string          Pattern to use when recording products. Files that match this pattern will be excluded as subjects on the attestation.
       --attestor-product-include-glob string          Pattern to use when recording products. Files that match this pattern will be included as subjects on the attestation. (default "*")
       --enable-archivista                             Use Archivista to store or retrieve attestations
+      --hashes strings                                Hashes selected for digest calculation. Defaults to SHA256 (default [sha256])
   -h, --help                                          help for run
   -o, --outfile string                                File to which to write signed data.  Defaults to stdout
       --signer-file-cert-path string                  Path to the file containing the certificate for the private key

--- a/options/run.go
+++ b/options/run.go
@@ -25,6 +25,7 @@ type RunOptions struct {
 	ArchivistaOptions  ArchivistaOptions
 	WorkingDir         string
 	Attestations       []string
+	Hashes             []string
 	OutFilePath        string
 	StepName           string
 	Tracing            bool
@@ -37,6 +38,7 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	ro.ArchivistaOptions.AddFlags(cmd)
 	cmd.Flags().StringVarP(&ro.WorkingDir, "workingdir", "d", "", "Directory from which commands will run")
 	cmd.Flags().StringSliceVarP(&ro.Attestations, "attestations", "a", []string{"environment", "git"}, "Attestations to record")
+	cmd.Flags().StringSliceVar(&ro.Hashes, "hashes", []string{"sha256"}, "Hashes selected for digest calculation. Defaults to SHA256")
 	cmd.Flags().StringVarP(&ro.OutFilePath, "outfile", "o", "", "File to which to write signed data.  Defaults to stdout")
 	cmd.Flags().StringVarP(&ro.StepName, "step", "s", "", "Name of the step being run")
 	cmd.Flags().BoolVar(&ro.Tracing, "trace", false, "Enable tracing for the command")


### PR DESCRIPTION
Introduce flag that allows for slice of string's indicating hash algorithms to be used for digest calculation. Uses go-witness.attestation.WithHashes to add the slice to attestation run options. Will error if can't parse hash from its string value.

Add to run tests to test for acceptable/unacceptable hash algorithms accepted

Refs: #73