### PR TITLE
docs: correct sign policy file command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ pubb64=`cat testpub.pem | base64 -w 0` && sed -i "s/{{B64_PUBLIC_KEY}}/$pubb64/g
 Keep this key safe, its owner will control the policy gates.
 
 ```
-witness sign -f policy.json --key testkey.pem --outfile policy-signed.json
+witness sign -f policy.json --signer-file-key-path testkey.pem --outfile policy-signed.json
 ```
 
 ### Verify the Binary Meets Policy Requirements


### PR DESCRIPTION
Fixup of https://github.com/in-toto/witness/pull/289

Before
```
witness sign -f policy.json --key testkey.pem --outfile policy-signed.json
ERROR   unknown flag: --key 
```

After

```
witness sign -f policy.json --signer-file-key-path testkey.pem --outfile policy-signed.json
INFO    Using config file: .witness.yaml   
```
