### PR TITLE
Update README.md - fixing quickstart url

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Download from the releases page or use the install script to download the latest
 
 [Releases](https://github.com/testifysec/witness/releases)
 ```
-bash <(curl -s https://raw.githubusercontent.com/testifysec/witness/main/install-witness.sh)
+bash <(curl -s https://raw.githubusercontent.com/in-toto/witness/main/install-witness.sh)
 ```
 
 


### PR DESCRIPTION
Update README.md - fixing quickstart url. 

Old url/project does not have github releases and the script fails to read them. Updating to point to "in-toto" fixes it. 