### PR TITLE
Updated witness to use changes made to `cryptoutil.DigestValue` implemented in go-witness

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -121,7 +121,7 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 		if err != nil {
 			return fmt.Errorf("failed to parse hash: %w", err)
 		}
-		roHashes = append(roHashes, cryptoutil.DigestValue{Hash: hash})
+		roHashes = append(roHashes, cryptoutil.DigestValue{Hash: hash, GitOID: false})
 	}
 
 	defer out.Close()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"context"
-	"crypto"
 	"encoding/json"
 	"fmt"
 
@@ -116,13 +115,13 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 		}
 	}
 
-	var roHashes []crypto.Hash
+	var roHashes []cryptoutil.DigestValue
 	for _, hashStr := range ro.Hashes {
 		hash, err := cryptoutil.HashFromString(hashStr)
 		if err != nil {
 			return fmt.Errorf("failed to parse hash: %w", err)
 		}
-		roHashes = append(roHashes, hash)
+		roHashes = append(roHashes, cryptoutil.DigestValue{Hash: hash})
 	}
 
 	defer out.Close()

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -89,7 +89,7 @@ func runVerify(ctx context.Context, vo options.VerifyOptions) error {
 
 	subjects := []cryptoutil.DigestSet{}
 	if len(vo.ArtifactFilePath) > 0 {
-		artifactDigestSet, err := cryptoutil.CalculateDigestSetFromFile(vo.ArtifactFilePath, []crypto.Hash{crypto.SHA256})
+		artifactDigestSet, err := cryptoutil.CalculateDigestSetFromFile(vo.ArtifactFilePath, []cryptoutil.DigestValue{{Hash: crypto.SHA256}})
 		if err != nil {
 			return fmt.Errorf("failed to calculate artifact digest: %w", err)
 		}
@@ -125,10 +125,8 @@ func runVerify(ctx context.Context, vo options.VerifyOptions) error {
 		witness.VerifyWithSubjectDigests(subjects),
 		witness.VerifyWithCollectionSource(collectionSource),
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to verify policy: %w", err)
-
 	}
 
 	log.Info("Verification succeeded")
@@ -142,5 +140,4 @@ func runVerify(ctx context.Context, vo options.VerifyOptions) error {
 	}
 
 	return nil
-
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -89,7 +89,7 @@ func runVerify(ctx context.Context, vo options.VerifyOptions) error {
 
 	subjects := []cryptoutil.DigestSet{}
 	if len(vo.ArtifactFilePath) > 0 {
-		artifactDigestSet, err := cryptoutil.CalculateDigestSetFromFile(vo.ArtifactFilePath, []cryptoutil.DigestValue{{Hash: crypto.SHA256}})
+		artifactDigestSet, err := cryptoutil.CalculateDigestSetFromFile(vo.ArtifactFilePath, []cryptoutil.DigestValue{{Hash: crypto.SHA256, GitOID: false}})
 		if err != nil {
 			return fmt.Errorf("failed to calculate artifact digest: %w", err)
 		}

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -92,7 +92,7 @@ func TestRunVerifyCA(t *testing.T) {
 	require.NoError(t, runRun(context.Background(), s1RunOptions, step1Args, signers...))
 
 	subjects := []string{}
-	artifactDigest, err := cryptoutil.CalculateDigestSetFromFile(artifactPath, []crypto.Hash{crypto.SHA256})
+	artifactDigest, err := cryptoutil.CalculateDigestSetFromFile(artifactPath, []cryptoutil.DigestValue{{Hash: crypto.SHA256}})
 	require.NoError(t, err)
 
 	for _, digest := range artifactDigest {
@@ -128,7 +128,7 @@ func TestRunVerifyCA(t *testing.T) {
 	require.NoError(t, runVerify(context.Background(), vo))
 
 	// test that verify works without artifactfilepath but the subject of the modified articact also provided
-	artifactDigest, err = cryptoutil.CalculateDigestSetFromFile(artifactPath, []crypto.Hash{crypto.SHA256})
+	artifactDigest, err = cryptoutil.CalculateDigestSetFromFile(artifactPath, []cryptoutil.DigestValue{{Hash: crypto.SHA256}})
 	require.NoError(t, err)
 	for _, digest := range artifactDigest {
 		subjects = append(subjects, digest)
@@ -190,7 +190,7 @@ func TestRunVerifyKeyPair(t *testing.T) {
 	require.NoError(t, runRun(context.Background(), s1RunOptions, step1Args, signers...))
 
 	subjects := []string{}
-	artifactDigest, err := cryptoutil.CalculateDigestSetFromFile(artifactPath, []crypto.Hash{crypto.SHA256})
+	artifactDigest, err := cryptoutil.CalculateDigestSetFromFile(artifactPath, []cryptoutil.DigestValue{{Hash: crypto.SHA256}})
 	require.NoError(t, err)
 
 	for _, digest := range artifactDigest {
@@ -226,7 +226,7 @@ func TestRunVerifyKeyPair(t *testing.T) {
 	require.NoError(t, runVerify(context.Background(), vo))
 
 	// test that verify works without artifactfilepath but the subject of the modified articact also provided
-	artifactDigest, err = cryptoutil.CalculateDigestSetFromFile(artifactPath, []crypto.Hash{crypto.SHA256})
+	artifactDigest, err = cryptoutil.CalculateDigestSetFromFile(artifactPath, []cryptoutil.DigestValue{{Hash: crypto.SHA256}})
 	require.NoError(t, err)
 	for _, digest := range artifactDigest {
 		subjects = append(subjects, digest)
@@ -328,9 +328,7 @@ func makepolicy(t *testing.T, functionary policy.Functionary, publicKey policy.P
 	p.Steps[step02.Name] = step02
 
 	if publicKey.KeyID != "" {
-
 		p.PublicKeys[publicKey.KeyID] = publicKey
-
 	}
 
 	pb, err := json.MarshalIndent(p, "", "  ")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/in-toto/witness
 go 1.19
 
 require (
-	github.com/in-toto/go-witness v0.2.2
+	github.com/in-toto/go-witness v0.2.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/in-toto/go-witness v0.2.1 h1:eAxMBWUPbz3oPU3lsfEYi/Kdj6weej2umm59bOXP
 github.com/in-toto/go-witness v0.2.1/go.mod h1:xURJVj4QRD3xnzOJps7gT0pMCFPpAHcPqDC3EyuLuUE=
 github.com/in-toto/go-witness v0.2.2 h1:oyiqyzzKwX8j5zjBVdxoo0LxjMV13ujOF0l/hu5uYp8=
 github.com/in-toto/go-witness v0.2.2/go.mod h1:b5ocF+eHUYnQgQncM6nK0g5TIoUzA94gs50fS7g+uNk=
+github.com/in-toto/go-witness v0.2.3 h1:KjiaRHxW2VSyouXUW0Zrpc+7LXfFKilB86a1lqNDsAU=
+github.com/in-toto/go-witness v0.2.3/go.mod h1:b5ocF+eHUYnQgQncM6nK0g5TIoUzA94gs50fS7g+uNk=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
This is a quick PR after noticing that `witness/main` does not work with `go-witness` main due to changes merged in https://github.com/in-toto/go-witness/pull/139.

@mikhailswift I *set the `GitOID` field to `false`* everywhere, which I am not 100% is correct. If you could give this a review, please let me know if these fields need set differently.