### PR TITLE
fix: run e2e test script as part of workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,20 @@ jobs:
       artifact-upload-name: profile.cov
       artifact-upload-path: profile.cov
 
+  e2e-test:
+    needs: [fmt]
+    uses: ./.github/workflows/witness.yml
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read
+    with:
+      pull_request: ${{ github.event_name == 'pull_request' }}
+      step: unit-test
+      attestations: "git github environment"
+      command: cd test/ && ./test.sh
+      artifact-upload-name: profile.cov
+      artifact-upload-path: profile.cov
+
   release:
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       contents: read
     with:
       pull_request: ${{ github.event_name == 'pull_request' }}
-      step: unit-test
+      step: e2e-test
       attestations: "git github environment"
       command: cd test/ && ./test.sh
       artifact-upload-name: profile.cov


### PR DESCRIPTION
## What this PR does / why we need it

This runs the test script in test.sh, which tests a few end to end policy verification test cases.

This will fail until https://github.com/in-toto/go-witness/pull/173 is merged and the dependency updated.

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
