### PR TITLE
refactor: make all run options have shorthand vars

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,8 +80,8 @@ witness run [cmd] [flags]
       --signer-vault-ttl duration                     Time to live for the generated certificate. Defaults to the vault role policy's configured TTL if not provided
       --signer-vault-url string                       Base url of the Vault instance to connect to
   -s, --step string                                   Name of the step being run
-      --timestamp-servers strings                     Timestamp Authority Servers to use when signing envelope
-      --trace                                         Enable tracing for the command
+  -t, --timestamp-servers strings                     Timestamp Authority Servers to use when signing envelope
+  -r, --trace                                         Enable tracing for the command
   -d, --workingdir string                             Directory from which commands will run
 ```
 

--- a/options/run.go
+++ b/options/run.go
@@ -54,8 +54,8 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&ro.Hashes, "hashes", []string{"sha256"}, "Hashes selected for digest calculation. Defaults to SHA256")
 	cmd.Flags().StringVarP(&ro.OutFilePath, "outfile", "o", "", "File to write signed data to")
 	cmd.Flags().StringVarP(&ro.StepName, "step", "s", "", "Name of the step being run")
-	cmd.Flags().BoolVar(&ro.Tracing, "trace", false, "Enable tracing for the command")
-	cmd.Flags().StringSliceVar(&ro.TimestampServers, "timestamp-servers", []string{}, "Timestamp Authority Servers to use when signing envelope")
+	cmd.Flags().BoolVarP(&ro.Tracing, "trace", "r", false, "Enable tracing for the command")
+	cmd.Flags().StringSliceVarP(&ro.TimestampServers, "timestamp-servers", "t", []string{}, "Timestamp Authority Servers to use when signing envelope")
 
 	cmd.MarkFlagsRequiredTogether(RequiredRunFlags...)
 


### PR DESCRIPTION
Refactor: Simple nitpick refactor to have all run option flags have shorthand vars.

Description

I was looking at my old PR that added hashes as run options flags and realized it and others did not have shorthand vars like the majority of the run options flags. So, I threw this nit PR up just in case y'all believe its best to align and have all run options flags have shorthand vars.

Feel free to close PR if you don't agree.