### PR TITLE
fix(install-witness.sh): ensure compatibility with macOS for checksum verification

### DIFF
--- a/install-witness.sh
+++ b/install-witness.sh
@@ -80,7 +80,11 @@ cd "$TEMPDIR"
 curl -s -LO "$DOWNLOAD_URL"
 
 # Verify the checksum
-FILE_CHECKSUM=$(sha256sum -b "witness_${VERSION}_${OS}_${ARCH}.tar.gz" | awk '{print $1}')
+if command -v sha256sum >/dev/null 2>&1; then
+    FILE_CHECKSUM=$(sha256sum -b "witness_${VERSION}_${OS}_${ARCH}.tar.gz" | awk '{print $1}')
+else
+    FILE_CHECKSUM=$(shasum -a 256 "witness_${VERSION}_${OS}_${ARCH}.tar.gz" | awk '{print $1}')
+fi
 
 echo file checksum: "    $FILE_CHECKSUM"
 


### PR DESCRIPTION
The install-witness.sh script did not work on macOS due to the absence of the sha256sum command.
This patch adds a check to use shasum -a 256 if sha256sum is not available, ensuring the script
runs correctly on macOS.

- Added a conditional check to use shasum -a 256 when sha256sum is not found
- Updated the FILE_CHECKSUM assignment to support both commands

Closes #458

Signed-off-by: Frederick F. Kautz IV <frederick@testifysec.com>
