### PR TITLE
Remove Windows Arm64 build until fixed

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     main: ./
 gomod:
   proxy: false


### PR DESCRIPTION
## What this PR does / why we need it

Temporarily remove Windows arm64 builds
