### PR TITLE
fix: temporarily disable omnitrail on windows builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
     main: ./
 gomod:
   proxy: false

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.2
 
 require (
-	github.com/in-toto/go-witness v0.5.1
+	github.com/in-toto/go-witness v0.5.2
 	github.com/invopop/jsonschema v0.12.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sigstore/fulcio v1.4.5

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/in-toto/attestation v1.0.2 h1:ICqV41bfaDC3ixVUzAtFxFu+Dy56EPcjiIrJQe+
 github.com/in-toto/attestation v1.0.2/go.mod h1:3uRayZSKuCHDDZOxLm5UfYulqqd1L1NdzYvxX/jyZEM=
 github.com/in-toto/go-witness v0.5.1 h1:lrnFttDWEZqHxSfupcDGWTxSw8Uk/pNtVM1Wr3St0fo=
 github.com/in-toto/go-witness v0.5.1/go.mod h1:RN10WG5hFnK9OSHFlQD4mql54uCrtWdZ08/bl1vPuMI=
+github.com/in-toto/go-witness v0.5.2 h1:K2fEjIcHiEu639L9EmW9eIq/FsEO7amE9i0WGQlwQC0=
+github.com/in-toto/go-witness v0.5.2/go.mod h1:RN10WG5hFnK9OSHFlQD4mql54uCrtWdZ08/bl1vPuMI=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=


### PR DESCRIPTION
This updates go-witness to v0.5.2 which includes a build directive to disable compilation of the omnitrail attestor when targeting Windows.

## What this PR does / why we need it

Description

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
