### PR TITLE
fix: Passing kms provider options down to initialisation of functionaries

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -196,6 +196,7 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers ...crypt
 		witness.VerifyWithPolicyCAIntermediates(policyIntermediates),
 		witness.VerifyWithPolicyCertConstraints(vo.PolicyCommonName, vo.PolicyDNSNames, vo.PolicyEmails, vo.PolicyOrganizations, vo.PolicyURIs),
 		witness.VerifyWithPolicyFulcioCertExtensions(vo.PolicyFulcioCertExtensions),
+		witness.VerifyWithKMSProviderOptions(vo.KMSVerifierProviderOptions),
 	)
 	if err != nil {
 		if verifiedEvidence.StepResults != nil {


### PR DESCRIPTION
## What this PR does / why we need it

This PR closes https://github.com/in-toto/witness/issues/427 and is linked to https://github.com/in-toto/go-witness/pull/292, so will require a new release of `go-witness` before merge.