### PR TITLE
prevent early return in verifier

### DIFF
--- a/cmd/keyloader.go
+++ b/cmd/keyloader.go
@@ -120,7 +120,6 @@ func loadVerifiers(ctx context.Context, so options.VerifierOptions, ko options.K
 						continue
 					}
 					verifiers = append(verifiers, s)
-					return verifiers, nil
 				}
 			}
 		}


### PR DESCRIPTION
## What this PR does / why we need it

During verification there is nondeterministic behavior if the flag `--verifier-kms-aws-remote-verify=[true/false]` is not specified. I found that this is because there is an early return causing the default boolean `true` value to not be set for the `verifyRemotely` attribute.

In some instances, the first `ksp` in the outer loop will be `kms-gcp`. If using an AWS reference, then the proper verifyRemotely setter will not be run. Other times, the first `ksp` will be `kms-aws` and the proper setter will be called.

You can check this by running `witness verify --verifier-kms-ref [KMS_REF] -a [ATTESTATION] -f [ARTIFACT] -p policy.signed.json` using an AWS IAM account without the `Verify` permission. It will succeed sometimes and fail other times.


## Which issue(s) this PR fixes (optional)

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
