### PR TITLE
Use /usr/local/bin for witness install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
         with:
+          witness-install-dir: /usr/local/bin
           step: "build"
           attestations: "github"
           command: goreleaser release --clean

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -64,6 +64,7 @@ jobs:
           - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
             uses: testifysec/witness-run-action@79320a907f611f2fb40ced8e13c66af988b2d9db
             with:
+              witness-install-dir: /usr/local/bin
               step: pre-${{ inputs.step }}
               attestations: ${{ inputs.attestations }}
               command: /bin/sh -c "${{ inputs.pre-command }}"
@@ -73,6 +74,7 @@ jobs:
           - if: ${{ inputs.pull_request == false }}
             uses: testifysec/witness-run-action@79320a907f611f2fb40ced8e13c66af988b2d9db
             with:
+              witness-install-dir: /usr/local/bin
               step: ${{ inputs.step }}
               attestations: ${{ inputs.attestations }}
               command: /bin/sh -c "${{ inputs.command }}"


### PR DESCRIPTION
## What this PR does / why we need it

Update install path so as to not dirty git state.