### PR TITLE
chore: Fix gitlab image to correct golang version 1.23.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: golang:1.17
+image: golang:1.23.2
 
 stages:
   - build checks


### PR DESCRIPTION
## What this PR does / why we need it

The gitlab ci file used an old version of golang that does not match the project.

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [x] All workflow checks passing (automatically enforced)
- [x] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
