### PR TITLE
changed --env-exclude-sensitive-key to --env-allow-sensitive-key

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -144,7 +144,7 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 			attestation.WithHashes(roHashes),
 			attestation.WithDirHashGlob(ro.DirHashGlobs),
 			attestation.WithEnvCapturer(
-				ro.EnvAddSensitiveKeys, ro.EnvExcludeSensitiveKeys, ro.EnvDisableSensitiveVars, ro.EnvFilterSensitiveVars,
+				ro.EnvAddSensitiveKeys, ro.EnvAllowSensitiveKeys, ro.EnvDisableSensitiveVars, ro.EnvFilterSensitiveVars,
 			),
 		),
 		witness.RunWithTimestampers(timestampers...),

--- a/docs/attestors/environment.md
+++ b/docs/attestors/environment.md
@@ -24,7 +24,7 @@ you can use `--env-add-sensitive-key 'FOO'` for `FOO` or
 
 There could be cases where you really want to have a specific key that is part
 of the default sensitive vars list to be captured. You can do so by using the
-`--env-exclude-sensitive-key`.
+`--env-allow-sensitive-key`.
 
 ## Default sensitive vars
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -65,8 +65,8 @@ witness run [cmd] [flags]
       --dirhash-glob strings                              Dirhash glob can be used to collapse material and product hashes on matching directory matches.
       --enable-archivista                                 Use Archivista to store or retrieve attestations
       --env-add-sensitive-key strings                     Add keys or globs (e.g. '*TEXT') to the list of sensitive environment keys.
+      --env-allow-sensitive-key strings                   Allow specific keys from the list of sensitive environment keys. Note: This does not support globs.
       --env-disable-default-sensitive-vars                Disable the default list of sensitive vars and only use the items mentioned by --add-sensitive-key.
-      --env-exclude-sensitive-key strings                 Exclude specific keys from the list of sensitive environment keys. Note: This does not support globs.
       --env-filter-sensitive-vars                         Switch from obfuscate to filtering variables which removes them from the output completely.
       --hashes strings                                    Hashes selected for digest calculation. Defaults to SHA256 (default [sha256])
   -h, --help                                              help for run

--- a/options/run.go
+++ b/options/run.go
@@ -38,7 +38,7 @@ type RunOptions struct {
 	EnvFilterSensitiveVars   bool
 	EnvDisableSensitiveVars  bool
 	EnvAddSensitiveKeys      []string
-	EnvExcludeSensitiveKeys  []string
+	EnvAllowSensitiveKeys    []string
 }
 
 var RequiredRunFlags = []string{
@@ -67,7 +67,7 @@ func (ro *RunOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&ro.EnvFilterSensitiveVars, "env-filter-sensitive-vars", "", false, "Switch from obfuscate to filtering variables which removes them from the output completely.")
 	cmd.Flags().BoolVarP(&ro.EnvDisableSensitiveVars, "env-disable-default-sensitive-vars", "", false, "Disable the default list of sensitive vars and only use the items mentioned by --add-sensitive-key.")
 	cmd.Flags().StringSliceVar(&ro.EnvAddSensitiveKeys, "env-add-sensitive-key", []string{}, "Add keys or globs (e.g. '*TEXT') to the list of sensitive environment keys.")
-	cmd.Flags().StringSliceVar(&ro.EnvExcludeSensitiveKeys, "env-exclude-sensitive-key", []string{}, "Exclude specific keys from the list of sensitive environment keys. Note: This does not support globs.")
+	cmd.Flags().StringSliceVar(&ro.EnvAllowSensitiveKeys, "env-allow-sensitive-key", []string{}, "Allow specific keys from the list of sensitive environment keys. Note: This does not support globs.")
 
 	cmd.MarkFlagsRequiredTogether(RequiredRunFlags...)
 


### PR DESCRIPTION
## What this PR does / why we need it
Description

changed --env-exclude-sensitive-key to --env-allow-sensitive-key
## Which issue(s) this PR fixes (optional)
https://github.com/in-toto/witness/issues/556

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
