### PR TITLE
docs: add TestifySec sponsorship to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Witness
 [![Go Reference](https://pkg.go.dev/badge/github.com/in-toto/witness.svg)](https://pkg.go.dev/github.com/in-toto/witness) [![Go Report Card](https://goreportcard.com/badge/github.com/in-toto/witness)](https://goreportcard.com/report/github.com/in-toto/witness) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8164/badge)](https://www.bestpractices.dev/projects/8164) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/in-toto/witness/badge)](https://securityscorecards.dev/viewer/?uri=github.com/in-toto/witness) [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B41709%2Fgithub.com%2Fin-toto%2Fwitness.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B41709%2Fgithub.com%2Fin-toto%2Fwitness?ref=badge_shield&issueType=license)
 
+> **Sponsored by [TestifySec](https://www.testifysec.com)** - We provide an enterprise platform for storing, visualizing, and managing your attestations at scale. Get centralized attestation management, advanced analytics, and professional support. [Contact us](https://www.testifysec.com/contact) to learn more.
+
 <center>
 
 **[DOCS](https://witness.dev) •

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,4 @@
 
 [build.environment]
   NODE_VERSION = "20.18.1"
+  SECRETS_SCAN_SMART_DETECTION_ENABLED = "false"


### PR DESCRIPTION
## Summary
This PR adds TestifySec sponsorship information to the README and fixes a Netlify build issue.

## Changes
### Sponsorship Addition
- Added sponsorship banner after badges section in README
- Highlights TestifySec's enterprise platform for attestation storage, visualization, and management
- Includes contact link for enterprise support inquiries

### Netlify Build Fix
- Disabled Netlify smart detection to resolve false positive in secrets scanner
- The scanner was detecting 'LS0t' (base64 for '---') from PEM headers in build output

## Test plan
- [ ] Verify README renders correctly with new sponsorship section
- [ ] Confirm sponsorship links work properly
- [ ] Ensure Netlify build passes without secrets scanner false positives