### PR TITLE
Update README and MAINTAINERS

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,8 @@
 | Name                       | GitHub          |
 |----------------------------|-----------------|
 | Cole Kennedy (TestifySec)  | [@colek42](https://github.com/colek42) |
-| John Kjell (ControlPlane)  | [@jkjell](https://github.com/jkjell) |
-| Tom Meadows (TestifySec)   | [@ChaosInTheCRD](https://github.com/ChaosInTheCRD) |
-| Aditya Sirish (NYU)        | [@adityasaky](https://github.com/adityasaky) |
-| Mikhail Swift (TestifySec) | [@mikhailswift](https://github.com/mikhailswift) |
+| John Kjell (Control Plane)  | [@jkjell](https://github.com/jkjell) |
+| Tom Meadows (Tailscale)   | [@ChaosInTheCRD](https://github.com/ChaosInTheCRD) |
+| Aditya Sirish (Bloomberg)  | [@adityasaky](https://github.com/adityasaky) |
+| Mikhail Swift | [@mikhailswift](https://github.com/mikhailswift) |
+| Frederick Kautz (TestifySec) | [@fkautz](https://github.com/fkautz) |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Witness
 [![Go Reference](https://pkg.go.dev/badge/github.com/in-toto/witness.svg)](https://pkg.go.dev/github.com/in-toto/witness) [![Go Report Card](https://goreportcard.com/badge/github.com/in-toto/witness)](https://goreportcard.com/report/github.com/in-toto/witness) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8164/badge)](https://www.bestpractices.dev/projects/8164) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/in-toto/witness/badge)](https://securityscorecards.dev/viewer/?uri=github.com/in-toto/witness) [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B41709%2Fgithub.com%2Fin-toto%2Fwitness.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B41709%2Fgithub.com%2Fin-toto%2Fwitness?ref=badge_shield&issueType=license)
 
-> **Sponsored by [TestifySec](https://www.testifysec.com)** - We provide an enterprise platform for storing, visualizing, and managing your attestations at scale. Get centralized attestation management, advanced analytics, and professional support. [Contact us](https://www.testifysec.com/contact) to learn more.
+Witness originated at **[TestifySec](https://www.testifysec.com)** and was later donated to the CNCF in-toto ecosystem. It is now maintained by the open community.
 
 <center>
 
@@ -71,7 +71,10 @@ Check out some of the content out in the wild that gives more detail on how the 
 Join the [CNCF Slack](https://slack.cncf.io/) and join the `#in-toto-witness` channel. You might also be interested in joining the `#in-toto` channel for more general in-toto discussion, as well as
 the `#in-toto-archivista` channel for discussion regarding the [Archivista](https://github.com/in-toto/archivista) project.
 
-## Background
-This project was created by [TestifySec](https://www.testifysec.com/) before being donated to the in-toto project. The project is maintained by the TestifySec Open Source team and a community of contributors.
+## Community & Commercial Support
+
+- **Community channels** – Slack, GitHub Issues, and bi-weekly office hours are free and open to all contributors.
+- **Commercial platform & SLAs** – [TestifySec](https://www.testifysec.com) offers managed Witness/Archivista hosting, and 24 × 7 support.  
+  <sup>(These commercial services are provided by TestifySec and are not part of the CNCF sponsorship of Witness.)</sup>
 
 [demo]: https://raw.githubusercontent.com/in-toto/witness/main/docs/assets/demo.gif "Demo"


### PR DESCRIPTION
## Summary
- Update Background section to reflect Witness origins at TestifySec and donation to CNCF
- Add Community & Commercial Support section with details about community channels and TestifySec's commercial offerings
- Update maintainer affiliations and add Frederick Kautz

## Test plan
- [x] Review README.md for accuracy
- [x] Verify MAINTAINERS.md formatting is correct