### PR TITLE
Remove announcement bar with docs survey callout

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -107,14 +107,6 @@ const config = {
 
         ],
       },
-    announcementBar: {
-      id: 'support_us',
-      content:
-        'We are looking to revamp our docs, please fill <a target="_blank" rel="noopener noreferrer" href="https://forms.gle/Pcgo45TABFYvfQX47">this survey</a>',
-      textColor: 'white',
-      backgroundColor: '#333385',
-      isCloseable: false,
-    },
       footer: {
         style: 'dark',
         links: [


### PR DESCRIPTION
There is announcement bar at the top of every page on https://witness.dev/. This announcement bar is now completely outdated and (as far as I know) lost on an old Google account of mine. This PR removes it.

I'm also pretty sure that this will require a redeploy on Netlify? cc'ing @colek42.