### PR TITLE
fix: gitignore profile.cov file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ build/
 vendor/
 .dccache
 .vscode
-.profile.cov
+profile.cov
 test/testapp
 test/test-attestation.json
 test/policy-signed.json


### PR DESCRIPTION
## What this PR does / why we need it
When I run `make test`, the coverprofile is mentioned as `profile.cov`, but in the .gitignore it was `.profile.cov`

```ts
go test -v -coverprofile=profile.cov -covermode=atomic ./...
```
Description

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
