### PR TITLE
test: add cmd/version.go

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(VerifyCmd())
 	cmd.AddCommand(RunCmd())
 	cmd.AddCommand(CompletionCmd())
-	cmd.AddCommand(versionCmd())
+	cmd.AddCommand(VersionCmd())
 	cmd.AddCommand(AttestorsCmd())
 	cobra.OnInitialize(func() { preRoot(cmd, ro, logger) })
 	cobra.OnFinalize((func() { postRoot(ro, logger) }))

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,7 +23,7 @@ import (
 var Version = "dev"
 
 // versionCmd represents the version command
-func versionCmd() *cobra.Command {
+func VersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:               "version",
 		Short:             "Prints out the witness version",

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCmd(t *testing.T) {
+	cmd := VersionCmd()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "version", cmd.Use)
+	assert.Equal(t, true, cmd.SilenceErrors)
+	assert.Equal(t, true, cmd.SilenceUsage)
+	assert.Equal(t, true, cmd.DisableAutoGenTag)
+
+	// Test the command execution and output
+	originalVersion := Version
+	defer func() { Version = originalVersion }()
+
+	// Redirect stdout to capture output
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Execute the command
+	cmd.Run(&cobra.Command{}, []string{})
+
+	// Restore stdout
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	// Read captured output
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	// Verify output
+	assert.Equal(t, "witness dev\n", buf.String())
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -34,8 +34,6 @@ func TestVersionCmd(t *testing.T) {
 	assert.Equal(t, true, cmd.DisableAutoGenTag)
 
 	// Test the command execution and output
-	originalVersion := Version
-	defer func() { Version = originalVersion }()
 
 	// Redirect stdout to capture output
 	oldStdout := os.Stdout


### PR DESCRIPTION
## What this PR does / why we need it
Improve test coverage - added a test for `cmd/version.go`

Ref: https://github.com/in-toto/witness/pull/571 (from this pr)

Description

## Which issue(s) this PR fixes (optional)

Part of #634


## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
