### PR TITLE
fix(docs): witness run cmd in kms

### DIFF
--- a/docs/signers/kms.md
+++ b/docs/signers/kms.md
@@ -9,7 +9,7 @@ Based on the KMS signer functionality presented in the [Sigstore Cosign project]
 If a user wanted to use a KMS Key (e.g., GCP KMS) to sign the result of a `witness run` command, they would use a command similar the following:
 
 ```yaml
-witness run -s test --signer-kms-ref=gcpkms://projects/test-project/locations/europe-west2/keyRings/test-keyring/cryptoKeys/test-key -- echo "hello world" > hello.txt
+witness run -s test -o test.json --signer-kms-ref=gcpkms://projects/test-project/locations/europe-west2/keyRings/test-keyring/cryptoKeys/test-key -- echo "hello world" > hello.txt
 ```
 
 Furthermore, if a user wanted to use a KMS Key (e.g., GCP KMS) to sign a policy, they could simply execute a command like:


### PR DESCRIPTION
## What this PR does / why we need it

Description
The fix is simply to add `-o test.json` in the run example, so that the later verify example makes sense. [here](https://witness.dev/docs/docs/signers/kms#verifying)

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
