### PR TITLE
fix(policy): add public key validation in policy check command

### DIFF
--- a/cmd/policy_check.go
+++ b/cmd/policy_check.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -25,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/in-toto/go-witness/dsse"
 	"github.com/in-toto/go-witness/log"
 	"github.com/in-toto/go-witness/policy"
@@ -274,6 +276,30 @@ func checkPolicy(cmd *cobra.Command, args []string) error {
 	}
 	if verbose && !jsonOutput {
 		log.Infof("Validated %d functionary root reference(s)", funcCount)
+	}
+
+	// Validate public keys
+	if verbose && !jsonOutput {
+		log.Info("Validating public keys...")
+	}
+	for k, v := range p.PublicKeys {
+		if verbose && !jsonOutput {
+			log.Infof("Checking public key '%s'...", k)
+		}
+
+		result.ChecksPerformed++
+		_, err := cryptoutil.TryParseKeyFromReader(bytes.NewReader(v.Key))
+		if err != nil {
+			result.Valid = false
+			result.Errors = append(result.Errors, ValidationError{
+				Category:   "Public Key",
+				Message:    fmt.Sprintf("Public key '%s' is not a valid PEM block: %v", k, err),
+				Suggestion: "Ensure the key field contains a base64-encoded PEM public key.\nExample: cat pubkey.pem | base64 | tr -d '\\n'",
+				Location:   fmt.Sprintf("publickeys.%s.key", k),
+			})
+			continue
+		}
+		result.ChecksPassed++
 	}
 
 	// Validate root certificates


### PR DESCRIPTION
## Description
This PR addresses an inconsistency reported in #721, where a policy with non PEM formatted public keys (e.g. raw base64 without headers) would successfully pass `witness policy check`, but subsequently crash `witness verify` with an `invalid pem block` error.

The root cause was that `cmd/policy_check.go` was verifying root certificates and Rego modules, but silently skipping any validation on the raw `PublicKeys` block. 

This commit adds `cryptoutil.TryParseKeyFromReader()` to the policy check loop. If an invalid key is detected, it will correctly mark the policy as invalid and prompt the user to ensure their key is a base64 encoded PEM public key.

## Related Issues
Fixes #721 

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)
