### PR TITLE
fix: properly retain attestor options on witness run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -106,7 +106,7 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 		}
 	}
 
-	for _, attestor := range attestors {
+	for i, attestor := range attestors {
 		setters, ok := ro.AttestorOptSetters[attestor.Name()]
 		if !ok {
 			continue
@@ -116,6 +116,8 @@ func runRun(ctx context.Context, ro options.RunOptions, args []string, signers .
 		if err != nil {
 			return fmt.Errorf("failed to set attestor option for %v: %w", attestor.Type(), err)
 		}
+
+		attestors[i] = attestor
 	}
 
 	var roHashes []cryptoutil.DigestValue


### PR DESCRIPTION

## What this PR does / why we need it

**Description**

This PR addresses a bug where attestor specific configurations (such as `--attestor-product-exclude-glob` or any other boolean/string flags specific to an individual attestor) were being ignored during the `witness run` phase.


### Root Cause
In `cmd/run.go`, when iterating over `attestors` to apply any provided flags via `registry.SetOptions()`, the updated configuration was continually scoped to the local loop variable because it was never reassigned back into the original array. As a result, the `witness.RunWithAttestors(attestors)` method call received the exact same unmodified attestor objects that it started with.

### Fix
Updated the loop iterator to provide the array index (`for i, attestor := range attestors`) and correctly re assign the returned config loaded object back into its proper place in the original slice (`attestors[i] = attestor`) before finishing initialization. 

## Fixes #704 

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)


