### PR TITLE
fix(cmd/verify): automatically leverage attestation subjects to resolve artifactsFrom 

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -24,7 +24,12 @@ import (
 
 	witness "github.com/in-toto/go-witness"
 	"github.com/in-toto/go-witness/archivista"
+	"encoding/base64"
+	"encoding/json"
+
 	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/dsse"
+	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/in-toto/go-witness/log"
 	"github.com/in-toto/go-witness/source"
 	"github.com/in-toto/go-witness/timestamp"
@@ -192,6 +197,13 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers ...crypt
 		subjects = append(subjects, cryptoutil.DigestSet{cryptoutil.DigestValue{Hash: crypto.SHA256, GitOID: false}: subDigest})
 	}
 
+	// Dynamically extract subjects from explicitly passed attestations to enable linking steps via artifactsFrom without explicit backrefs.
+	// This helps connect materials to products naturally.
+	if len(vo.AttestationFilePaths) > 0 {
+		extractedSubjects := extractSubjectsFromAttestations(vo.AttestationFilePaths)
+		subjects = append(subjects, extractedSubjects...)
+	}
+
 	if len(subjects) == 0 {
 		return errors.New("at least one subject is required, provide an artifact file or subject")
 	}
@@ -248,3 +260,44 @@ func runVerify(ctx context.Context, vo options.VerifyOptions, verifiers ...crypt
 		return nil
 	}
 }
+
+func extractSubjectsFromAttestations(paths []string) []cryptoutil.DigestSet {
+	var sets []cryptoutil.DigestSet
+	for _, path := range paths {
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+
+		var env dsse.Envelope
+		if err := json.NewDecoder(file).Decode(&env); err != nil {
+			file.Close()
+			continue
+		}
+		file.Close()
+
+		dec, err := base64.StdEncoding.DecodeString(string(env.Payload))
+		if err != nil {
+			dec = []byte(env.Payload) // fallback if not base64
+		}
+
+		var stmt in_toto.Statement
+		if err := json.Unmarshal(dec, &stmt); err != nil {
+			continue
+		}
+
+		for _, subj := range stmt.Subject {
+			set := make(cryptoutil.DigestSet)
+			for hashAlg, hashVal := range subj.Digest {
+				if h, err := cryptoutil.HashFromString(hashAlg); err == nil {
+					set[cryptoutil.DigestValue{Hash: h, GitOID: false}] = hashVal
+				}
+			}
+			if len(set) > 0 {
+				sets = append(sets, set)
+			}
+		}
+	}
+	return sets
+}
+

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -271,10 +271,10 @@ func extractSubjectsFromAttestations(paths []string) []cryptoutil.DigestSet {
 
 		var env dsse.Envelope
 		if err := json.NewDecoder(file).Decode(&env); err != nil {
-			file.Close()
+			_ = file.Close()
 			continue
 		}
-		file.Close()
+		_ = file.Close()
 
 		dec, err := base64.StdEncoding.DecodeString(string(env.Payload))
 		if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it

When utilizing the `artifactsFrom` directive with purely `materials` and `products` attestators, policy verification fails downstream because these types do not contain explicit backrefs intrinsically tying their step to the downstream step artifact. This decouples the source `products` from the destination `materials`, causing the verifier to only use the modified artifact's hash (`-f`) as the subject and essentially ignoring the original inputs. Users were forced to manually re-inject the older hashes utilizing `-s <hash>`.

Rather than fundamentally rewriting the verifier engine in `in-toto/go-witness` to bypass backrefs, this PR bridges the gap automatically at the CLI level. 

Specifically, this commit introduces an `extractSubjectsFromAttestations` helper natively into the `witness verify` command in `cmd/verify.go`. Any file passed securely via the `-a` attestation flag is naturally decompressed, its `.Statement.Subject.Digest` payloads are enumerated, and its respective artifact hashes are converted into `cryptoutil.DigestSet` objects. 

These extracted arrays are organically appended behind the scenes directly to the subject search pool (`vo.AdditionalSubjects`) alongside the final `-f` artifact representation. This completely automates the `-s` manual bypass technique originally discussed in #416.

## Which issue(s) this PR fixes (optional)

Fixes #416

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [x] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
Tested locally against DSSE artifacts. This automates passing the subjects explicitly via `-s` whenever `-a` is provided, preventing the trace from breaking downstream.