### PR TITLE
ci: add automatic PR labeling based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,71 @@
+# Configuration for actions/labeler
+# https://github.com/actions/labeler
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'docs-website/**'
+          - 'docgen/**'
+          - '**/*.md'
+
+attestors:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/attestors/**'
+          - 'cmd/attestors.go'
+          - 'cmd/attestors_test.go'
+
+signers:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/signers/**'
+          - 'options/signers.go'
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/**'
+          - 'options/**'
+          - 'main.go'
+
+policy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/policy/**'
+          - 'cmd/policy.go'
+          - 'cmd/policy_check.go'
+
+oci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'oci/**'
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'test/**'
+          - '**/*_test.go'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'go.mod'
+          - 'go.sum'
+          - 'vendor/**'
+          - 'docs-website/package.json'
+          - 'docs-website/yarn.lock'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - '.goreleaser.yaml'
+          - '.gitlab-ci.yml'
+          - 'Makefile'
+
+release:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.goreleaser.yaml'
+          - 'cmd/version.go'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true


### PR DESCRIPTION
## What this PR does / why we need it

Description
Adds a GitHub Actions workflow using actions/labeler@v5 to automatically label PRs based on which files are changed (e.g., documentation, attestors, signers, cli, policy, etc.)

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
