### PR TITLE
fix(ci): save attestations and upload to workflow run instead of sending to archivista

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       pull_request: ${{ github.event_name == 'pull_request' }}
       step: e2e-test
       attestations: "git github environment"
-      command: cd test/ && ./test.sh
+      command: "cd test/ && ./test.sh"
       artifact-upload-name: profile.cov
       artifact-upload-path: profile.cov
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
         with:
+          step: "release"
+          attestations: "git github slsa"
+          version: 0.11.0
+          outfile: release-attestation.json
+          enable-archivista: false
           witness-install-dir: /usr/local/bin
-          version: 0.9.1
-          step: "build"
-          attestations: "github"
           command: goreleaser release --clean
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-attestation
+          path: release-attestation.json

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -55,8 +55,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -82,7 +86,9 @@ jobs:
           name: pre-${{ inputs.step }}-attestation
           path: pre-${{ inputs.step }}-attestation.json
       - if: ${{ inputs.pre-command != '' && inputs.pull_request == true }}
-        run: ${{ inputs.pre-command }}
+        run: bash -c "${INPUTS_COMMAND}"
+        env:
+          INPUTS_PRE_COMMAND: ${{ inputs.pre-command }}
 
       - if: ${{ inputs.pull_request == false }}
         uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
@@ -100,7 +106,9 @@ jobs:
           name: ${{ inputs.step }}-attestation
           path: ${{ inputs.step }}-attestation.json
       - if: ${{ inputs.pull_request == true }}
-        run: ${{ inputs.command }}
+        run: bash -c "${INPUTS_COMMAND}"
+        env:
+          INPUTS_COMMAND: ${{ inputs.command }}
 
       - if: ${{ inputs.artifact-upload-path != '' && inputs.artifact-upload-name != ''}}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -50,6 +50,11 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -64,22 +69,36 @@ jobs:
       - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
         uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
         with:
-          witness-install-dir: /usr/local/bin
-          version: 0.9.1
           step: pre-${{ inputs.step }}
           attestations: ${{ inputs.attestations }}
+          version: 0.11.0
+          outfile: pre-${{ inputs.step }}-attestation.json
+          enable-archivista: false
+          witness-install-dir: /usr/local/bin
           command: /bin/sh -c "${{ inputs.pre-command }}"
+      - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pre-${{ inputs.step }}-attestation
+          path: pre-${{ inputs.step }}-attestation.json
       - if: ${{ inputs.pre-command != '' && inputs.pull_request == true }}
         run: ${{ inputs.pre-command }}
 
       - if: ${{ inputs.pull_request == false }}
         uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
         with:
-          witness-install-dir: /usr/local/bin
-          version: 0.9.1
           step: ${{ inputs.step }}
           attestations: ${{ inputs.attestations }}
+          version: 0.11.0
+          outfile: ${{ inputs.step }}-attestation.json
+          enable-archivista: false
+          witness-install-dir: /usr/local/bin
           command: /bin/sh -c "${{ inputs.command }}"
+      - if: ${{ inputs.pull_request == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.step }}-attestation
+          path: ${{ inputs.step }}-attestation.json
       - if: ${{ inputs.pull_request == true }}
         run: ${{ inputs.command }}
 

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -55,10 +55,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-           go-version-file: "go.mod"
+          go-version-file: "go.mod"
 
       - if: ${{ inputs.artifact-download != '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## What this PR does / why we need it

save attestations and upload to workflow run instead of sending to archivista. we can reenable archivista once a new public instance is available.