### PR TITLE
fix: error explicitly when file signer flags are set without a key path

### DIFF
--- a/cmd/keyloader.go
+++ b/cmd/keyloader.go
@@ -22,6 +22,7 @@ import (
 	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/in-toto/go-witness/log"
 	"github.com/in-toto/go-witness/signer"
+	"github.com/in-toto/go-witness/signer/file"
 	"github.com/in-toto/go-witness/signer/kms"
 	"github.com/in-toto/witness/options"
 	"github.com/spf13/pflag"
@@ -66,6 +67,18 @@ func loadSigners(ctx context.Context, so options.SignerOptions, ko options.KMSSi
 						continue
 					}
 				}
+			}
+		}
+
+		// The file signer provider is activated as soon as any --signer-file-*
+		// flag is set, but a certificate, intermediate, or passphrase is useless
+		// without a key to pair it with. Left unchecked, this provider silently
+		// fails to build below while any other configured signer (e.g. KMS)
+		// still succeeds, so the command exits 0 with the certificate quietly
+		// dropped instead of surfacing a clear, actionable error.
+		if fsp, ok := sp.(file.FileSignerProvider); ok && fsp.KeyPath == "" {
+			if fsp.CertPath != "" || len(fsp.IntermediatePaths) > 0 || fsp.PassphrasePath != "" || fsp.Passphrase != nil {
+				return nil, fmt.Errorf("--signer-file-key-path is required when other --signer-file-* flags (e.g. --signer-file-cert-path) are set; attaching a file-based certificate to a non-file signer such as KMS is not currently supported")
 			}
 		}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -105,6 +105,29 @@ func Test_loadSignersCertificate(t *testing.T) {
 	require.IsType(t, &cryptoutil.X509Signer{}, signers[0])
 }
 
+// Test_loadSignersCertificateWithoutKey reproduces
+// https://github.com/in-toto/witness/issues/573: passing --signer-file-cert-path
+// without --signer-file-key-path (e.g. because the certificate was meant for a
+// KMS-based signer) must fail loudly with an actionable error instead of being
+// silently swallowed when another signer provider succeeds.
+func Test_loadSignersCertificateWithoutKey(t *testing.T) {
+	_, _, leafcert, _ := fullChain(t)
+
+	signerOptions := options.SignerOptions{}
+	signerOptions["file"] = []func(signer.SignerProvider) (signer.SignerProvider, error){
+		func(sp signer.SignerProvider) (signer.SignerProvider, error) {
+			fsp := sp.(file.FileSignerProvider)
+			fsp.CertPath = leafcert.Name()
+			return fsp, nil
+		},
+	}
+
+	signers, err := loadSigners(context.Background(), signerOptions, options.KMSSignerProviderOptions{}, map[string]struct{}{"file": {}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "signer-file-key-path")
+	require.Len(t, signers, 0)
+}
+
 func rsakeypair(t *testing.T) (privatePem *os.File, publicPem *os.File) {
 	privatekey, err := rsa.GenerateKey(rand.Reader, keybits)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it

When `--signer-file-cert-path` (or `--signer-file-intermediate-paths` / `--signer-file-key-passphrase*`) is set without `--signer-file-key-path`, the file signer provider still gets activated (any `--signer-file-*` flag turns it on) and its build silently fails while logging an unclear error. If another signer provider (e.g. `--signer-kms-ref`) also succeeds, `loadSigners` was returning success anyway, since it only fails when *zero* signers loaded. The command exits `0` with the certificate quietly dropped instead of surfacing a clear, actionable error, exactly as reported and confirmed by a maintainer on the issue.

This PR adds an explicit check in `loadSigners` (`cmd/keyloader.go`): if the file signer provider is selected with a cert/intermediate/passphrase flag but no key path, it now returns a hard, immediate error instead of silently continuing.

## Which issue(s) this PR fixes (optional)

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [x] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:

This intentionally does not add BYOK certificate-embedding support for KMS signers (explicitly out of scope per the issue thread) — it only makes the existing incompatible-flag combination fail loudly instead of silently, per the maintainer's stated direction on the issue.

Fixes #573